### PR TITLE
Add Notion adapter with create_task and registry entry

### DIFF
--- a/action_engine/actions_registry.py
+++ b/action_engine/actions_registry.py
@@ -1,0 +1,10 @@
+"""Registry of supported actions for each platform."""
+
+from typing import Dict, List
+
+ACTIONS_REGISTRY: Dict[str, List[str]] = {
+    "gmail": ["perform_action"],
+    "google_calendar": ["create_event"],
+    "notion": ["create_task"],
+    "zapier": ["perform_action"],
+}

--- a/action_engine/adapters/notion_adapter.py
+++ b/action_engine/adapters/notion_adapter.py
@@ -1,3 +1,10 @@
-async def perform_action(params):
-    # כאן תבוא האינטגרציה האמיתית עם Notion
-    return {"message": "בוצעה פעולה ב־Notion", "params": params}
+async def create_task(payload):
+    """Create a task in Notion (mocked)."""
+    # Simulate interaction with Notion API
+    print(f"[Notion] Creating task with payload: {payload}")
+    return {
+        "status": "success",
+        "platform": "notion",
+        "message": "משימה נוצרה בהצלחה",
+        "data": payload,
+    }


### PR DESCRIPTION
## Summary
- implement `create_task` in `notion_adapter`
- add Notion to the central `ACTIONS_REGISTRY`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68814be97dd8832e824d8864a0acfd84