### PR TITLE
Implement dummy send_email action for Gmail

### DIFF
--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -1,3 +1,17 @@
 async def perform_action(params):
     # כאן תבוא האינטגרציה האמיתית עם Gmail
     return {"message": "בוצעה פעולה ב־Gmail", "params": params}
+
+
+async def send_email(payload):
+    """Simulate sending an email via Gmail."""
+    # Logging or debugging output for the mocked action
+    print(f"[Gmail] Sending email with payload: {payload}")
+
+    return {
+        "status": "success",
+        "platform": "gmail",
+        "message": "Email sent successfully",
+        "data": payload,
+    }
+


### PR DESCRIPTION
## Summary
- add `send_email` to Gmail adapter to simulate sending an email

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814efac710832e931f44323c98316f