### PR TITLE
Add simple action logging

### DIFF
--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -5,8 +5,8 @@ async def perform_action(params):
 
 async def send_email(payload):
     """Simulate sending an email via Gmail."""
-    # Logging or debugging output for the mocked action
-    print(f"[Gmail] Sending email with payload: {payload}")
+    # Basic logging for action invocation
+    print(f"[GMAIL] send_email called with payload: {payload}")
 
     return {
         "status": "success",

--- a/action_engine/adapters/google_calendar_adapter.py
+++ b/action_engine/adapters/google_calendar_adapter.py
@@ -5,7 +5,7 @@ async def create_event(payload):
     יוצר אירוע ביומן Google (מימוש ראשוני, דמיוני).
     """
     # תיעוד / הדמיה
-    print(f"[Google Calendar] Creating event with payload: {payload}")
+    print(f"[GOOGLE_CALENDAR] create_event called with payload: {payload}")
 
     # החזרה דמיונית
     return {

--- a/action_engine/adapters/notion_adapter.py
+++ b/action_engine/adapters/notion_adapter.py
@@ -1,7 +1,7 @@
 async def create_task(payload):
     """Create a task in Notion (mocked)."""
     # Simulate interaction with Notion API
-    print(f"[Notion] Creating task with payload: {payload}")
+    print(f"[NOTION] create_task called with payload: {payload}")
     return {
         "status": "success",
         "platform": "notion",


### PR DESCRIPTION
## Summary
- update `gmail_adapter.send_email` log message
- update `google_calendar_adapter.create_event` log message
- update `notion_adapter.create_task` log message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814fa751dc832e90db8424554f6801