### PR TITLE
Add README with overview and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Action Engine
+
+Action Engine is a lightweight FastAPI service for routing automation requests to various platforms. Requests are parsed and forwarded to platform specific adapters located in `action_engine/adapters`.
+
+## Folder structure
+
+- `action_engine/main.py` – FastAPI application entry point.
+- `action_engine/router.py` – routes requests to the correct adapter.
+- `action_engine/adapters/` – adapters for external platforms such as Gmail, Notion, Google Calendar and Zapier.
+- `action_engine/actions_registry.py` – registry describing available actions per platform.
+- Other directories (`auth`, `logging`, `scheduler`, `tests`, `utils`) contain placeholder modules for future extensions.
+
+## Running the app
+
+1. Install dependencies (for example with pip):
+
+   ```bash
+   pip install fastapi uvicorn
+   ```
+
+2. Start the FastAPI server with Uvicorn from the repository root:
+
+   ```bash
+   uvicorn action_engine.main:app --reload
+   ```
+
+The API exposes a `/perform_action` endpoint that accepts a JSON payload with `platform`, `action_type` and `payload` fields.
+
+## Supported platforms and actions
+
+The currently registered platforms and actions are defined in `actions_registry.py`:
+
+- **gmail**: `perform_action`
+- **google_calendar**: `create_event`
+- **notion**: `create_task`
+- **zapier**: `perform_action`
+
+Additional adapter functions (e.g. `send_email` in the Gmail adapter) can be used by calling the relevant function names via the API.


### PR DESCRIPTION
## Summary
- introduce project README
- describe folder structure and how to run the FastAPI service
- document supported platforms and actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815278cabc832eaccec97441afe8fa