### PR TITLE
Implement request validation and parsing

### DIFF
--- a/action_engine/action_parser.py
+++ b/action_engine/action_parser.py
@@ -1,0 +1,26 @@
+"""Utilities for converting validated requests into internal models."""
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from validator import ActionRequest
+
+
+@dataclass
+class ActionModel:
+    """Internal representation of an action to execute."""
+
+    action_type: str
+    platform: str
+    payload: Dict[str, Any]
+
+
+def parse_request(request: ActionRequest) -> ActionModel:
+    """Convert a validated ActionRequest into an ActionModel."""
+
+    return ActionModel(
+        action_type=request.action_type,
+        platform=request.platform,
+        payload=request.payload,
+    )
+

--- a/action_engine/main.py
+++ b/action_engine/main.py
@@ -1,15 +1,9 @@
 from fastapi import FastAPI
-from pydantic import BaseModel
-from typing import Dict, Any
 from router import route_action
+from validator import ActionRequest
 
 app = FastAPI()
 
-# ✅ עדכון: מודל בקשה מלא עם כל השדות
-class ActionRequest(BaseModel):
-    action_type: str
-    platform: str
-    payload: Dict[str, Any]
 
 @app.post("/perform_action")
 async def perform_action(request: ActionRequest):

--- a/action_engine/router.py
+++ b/action_engine/router.py
@@ -1,4 +1,8 @@
 from fastapi.responses import JSONResponse
+from fastapi import HTTPException
+
+from validator import validate_request
+from action_parser import parse_request
 
 # ייבוא אדפטרים
 from adapters import (
@@ -17,9 +21,15 @@ adapter_registry = {
 }
 
 async def route_action(data):
-    platform = data.get("platform")
-    action_type = data.get("action_type")
-    payload = data.get("payload", {})
+    try:
+        request_model = validate_request(data)
+    except HTTPException as exc:
+        return JSONResponse(content={"error": exc.detail}, status_code=exc.status_code)
+
+    action = parse_request(request_model)
+    platform = action.platform
+    action_type = action.action_type
+    payload = action.payload
 
     if platform == "test":
         return JSONResponse(content={"message": "המערכת עובדת 🎯"})

--- a/action_engine/validator.py
+++ b/action_engine/validator.py
@@ -1,0 +1,45 @@
+"""Request validation utilities."""
+
+from typing import Any, Dict
+
+from fastapi import HTTPException
+from pydantic import BaseModel, ValidationError
+
+
+class ActionRequest(BaseModel):
+    """Incoming request model from the API layer."""
+
+    action_type: str
+    platform: str
+    payload: Dict[str, Any]
+
+
+def validate_request(data: Dict[str, Any]) -> ActionRequest:
+    """Validate that the incoming data contains the required fields.
+
+    Parameters
+    ----------
+    data: Dict[str, Any]
+        Raw request data.
+
+    Returns
+    -------
+    ActionRequest
+        Parsed request model.
+
+    Raises
+    ------
+    HTTPException
+        If required fields are missing or parsing fails.
+    """
+
+    required_fields = ["action_type", "platform", "payload"]
+    for field in required_fields:
+        if field not in data or data[field] is None:
+            raise HTTPException(status_code=422, detail=f"Missing required field: '{field}'")
+
+    try:
+        return ActionRequest(**data)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+


### PR DESCRIPTION
## Summary
- implement `validate_request` and `ActionRequest`
- parse requests into an internal `ActionModel`
- validate and parse requests in `router.route_action`
- use shared `ActionRequest` model in `main`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881527cd89c832ea55fb8cf2443962e