### PR TITLE
Add placeholder API logic and new Zapier trigger

### DIFF
--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -3,8 +3,12 @@ async def perform_action(params):
     return {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
 
-async def send_email(payload):
-    """Simulate sending an email via Gmail."""
+async def send_email(payload: dict) -> dict:
+    """Send an email via Gmail.
+
+    This function currently mocks the interaction with the Gmail API and
+    simply echoes back the provided payload.
+    """
     # Basic logging for action invocation
     print(f"[GMAIL] send_email called with payload: {payload}")
 

--- a/action_engine/adapters/google_calendar_adapter.py
+++ b/action_engine/adapters/google_calendar_adapter.py
@@ -7,6 +7,9 @@ async def create_event(payload):
     # תיעוד / הדמיה
     print(f"[GOOGLE_CALENDAR] create_event called with payload: {payload}")
 
+    # Placeholder for Google Calendar API integration
+    # Example: await google_calendar_client.create_event(payload)
+
     # החזרה דמיונית
     return {
         "status": "success",

--- a/action_engine/adapters/notion_adapter.py
+++ b/action_engine/adapters/notion_adapter.py
@@ -2,6 +2,9 @@ async def create_task(payload):
     """Create a task in Notion (mocked)."""
     # Simulate interaction with Notion API
     print(f"[NOTION] create_task called with payload: {payload}")
+
+    # Placeholder for Notion API integration
+    # Example: await notion_client.create_task(payload)
     return {
         "status": "success",
         "platform": "notion",

--- a/action_engine/adapters/zapier_adapter.py
+++ b/action_engine/adapters/zapier_adapter.py
@@ -1,3 +1,18 @@
 async def perform_action(params):
     # כאן תבוא האינטגרציה עם Zapier Webhook / Trigger
     return {"message": "בוצעה פעולה דרך Zapier", "params": params}
+
+
+async def trigger_zap(payload: dict) -> dict:
+    """Trigger a Zap via webhook (mocked)."""
+    print(f"[ZAPIER] trigger_zap called with payload: {payload}")
+
+    # Placeholder for actual webhook call
+    # Example: await zapier_client.trigger(payload)
+
+    return {
+        "status": "success",
+        "platform": "zapier",
+        "message": "Zap triggered successfully",
+        "data": payload,
+    }


### PR DESCRIPTION
## Summary
- add typing and docstring for Gmail adapter
- add placeholder API integrations for Google Calendar and Notion
- implement `trigger_zap` function for Zapier adapter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881527e24f4832e87745501985c7a41