### PR TITLE
Implement OAuth client and token store

### DIFF
--- a/action_engine/auth/oauth_client.py
+++ b/action_engine/auth/oauth_client.py
@@ -1,0 +1,25 @@
+class OAuthClient:
+    """Basic OAuth client stub for initiating and completing authorization."""
+
+    def __init__(self, client_id: str, client_secret: str, redirect_uri: str):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+
+    async def initiate_authorization(self, scope: str) -> str:
+        """Simulate starting an OAuth authorization flow and return an auth URL."""
+        # In a real implementation this would generate the provider's auth URL
+        # including client_id, scope, redirect_uri and possibly state parameter.
+        return f"https://auth.example.com/authorize?client_id={self.client_id}&scope={scope}&redirect_uri={self.redirect_uri}"
+
+    async def fetch_token(self, authorization_response: str) -> dict:
+        """Simulate exchanging the authorization response for an access token."""
+        # Actual implementation would exchange the provided authorization code
+        # with the provider's token endpoint. Here we simply return a dummy token.
+        return {
+            "access_token": "dummy-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "authorization_response": authorization_response,
+        }
+

--- a/action_engine/auth/token_manager.py
+++ b/action_engine/auth/token_manager.py
@@ -1,0 +1,17 @@
+"""Simple in-memory token storage utilities."""
+
+from typing import Dict
+
+# In-memory storage for tokens keyed by platform name
+_token_store: Dict[str, str] = {}
+
+
+def get_token(platform: str) -> str | None:
+    """Retrieve a stored token for the given platform."""
+    return _token_store.get(platform)
+
+
+def set_token(platform: str, token: str) -> None:
+    """Store the access token for the given platform."""
+    _token_store[platform] = token
+


### PR DESCRIPTION
## Summary
- stub OAuth client with async methods for authorization flow
- add in-memory token manager with simple getters/setters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815281c170832e926de232d6b6ee39