### PR TITLE
Add user-specific token handling

### DIFF
--- a/action_engine/action_parser.py
+++ b/action_engine/action_parser.py
@@ -12,6 +12,7 @@ class ActionModel:
 
     action_type: str
     platform: str
+    user_id: str
     payload: Dict[str, Any]
 
 
@@ -21,6 +22,7 @@ def parse_request(request: ActionRequest) -> ActionModel:
     return ActionModel(
         action_type=request.action_type,
         platform=request.platform,
+        user_id=request.user_id,
         payload=request.payload,
     )
 

--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -6,24 +6,47 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from action_engine.logging.logger import get_logger
+from auth.token_manager import get_token
 
 logger = get_logger(__name__)
 
 
-async def perform_action(params):
-    # כאן תבוא האינטגרציה האמיתית עם Gmail
-    logger.info("Gmail perform_action invoked", extra={"params": params})
+async def perform_action(user_id: str, params: dict):
+    """Mock action execution for Gmail."""
+    token = get_token(user_id, "gmail")
+    if not token:
+        logger.info(
+            "Gmail token missing",
+            extra={"user_id": user_id, "platform": "gmail"},
+        )
+        return {"status": "error", "message": "Missing token for gmail"}
+
+    logger.info(
+        "Gmail perform_action invoked",
+        extra={"params": params, "user_id": user_id},
+    )
     return {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
 
-async def send_email(payload: dict) -> dict:
+async def send_email(user_id: str, payload: dict) -> dict:
     """Send an email via Gmail.
 
     This function currently mocks the interaction with the Gmail API and
     simply echoes back the provided payload.
     """
     # Basic logging for action invocation
-    logger.info("Gmail send_email", extra={"payload": payload})
+    token = get_token(user_id, "gmail")
+    if not token:
+        logger.info(
+            "Gmail token missing",
+            extra={"user_id": user_id, "platform": "gmail"},
+        )
+        return {"status": "error", "message": "Missing token for gmail"}
+
+    logger.info(
+        "Gmail send_email",
+        extra={"payload": payload, "user_id": user_id},
+    )
 
     return {
         "status": "success",

--- a/action_engine/adapters/google_calendar_adapter.py
+++ b/action_engine/adapters/google_calendar_adapter.py
@@ -7,16 +7,28 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from action_engine.logging.logger import get_logger
+from auth.token_manager import get_token
 
 logger = get_logger(__name__)
 
 
-async def create_event(payload):
+async def create_event(user_id: str, payload: dict):
     """
     יוצר אירוע ביומן Google (מימוש ראשוני, דמיוני).
     """
     # תיעוד / הדמיה
-    logger.info("Google Calendar create_event", extra={"payload": payload})
+    token = get_token(user_id, "google_calendar")
+    if not token:
+        logger.info(
+            "Google Calendar token missing",
+            extra={"user_id": user_id, "platform": "google_calendar"},
+        )
+        return {"status": "error", "message": "Missing token for google_calendar"}
+
+    logger.info(
+        "Google Calendar create_event",
+        extra={"payload": payload, "user_id": user_id},
+    )
 
     # Placeholder for Google Calendar API integration
     # Example: await google_calendar_client.create_event(payload)

--- a/action_engine/adapters/notion_adapter.py
+++ b/action_engine/adapters/notion_adapter.py
@@ -6,14 +6,26 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from action_engine.logging.logger import get_logger
+from auth.token_manager import get_token
 
 logger = get_logger(__name__)
 
 
-async def create_task(payload):
+async def create_task(user_id: str, payload: dict):
     """Create a task in Notion (mocked)."""
     # Simulate interaction with Notion API
-    logger.info("Notion create_task", extra={"payload": payload})
+    token = get_token(user_id, "notion")
+    if not token:
+        logger.info(
+            "Notion token missing",
+            extra={"user_id": user_id, "platform": "notion"},
+        )
+        return {"status": "error", "message": "Missing token for notion"}
+
+    logger.info(
+        "Notion create_task",
+        extra={"payload": payload, "user_id": user_id},
+    )
 
     # Placeholder for Notion API integration
     # Example: await notion_client.create_task(payload)

--- a/action_engine/adapters/zapier_adapter.py
+++ b/action_engine/adapters/zapier_adapter.py
@@ -6,19 +6,42 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from action_engine.logging.logger import get_logger
+from auth.token_manager import get_token
 
 logger = get_logger(__name__)
 
 
-async def perform_action(params):
-    # כאן תבוא האינטגרציה עם Zapier Webhook / Trigger
-    logger.info("Zapier perform_action", extra={"params": params})
+async def perform_action(user_id: str, params: dict):
+    """Mock integration with Zapier Webhook / Trigger."""
+    token = get_token(user_id, "zapier")
+    if not token:
+        logger.info(
+            "Zapier token missing",
+            extra={"user_id": user_id, "platform": "zapier"},
+        )
+        return {"status": "error", "message": "Missing token for zapier"}
+
+    logger.info(
+        "Zapier perform_action",
+        extra={"params": params, "user_id": user_id},
+    )
     return {"message": "בוצעה פעולה דרך Zapier", "params": params}
 
 
-async def trigger_zap(payload: dict) -> dict:
+async def trigger_zap(user_id: str, payload: dict) -> dict:
     """Trigger a Zap via webhook (mocked)."""
-    logger.info("Zapier trigger_zap", extra={"payload": payload})
+    token = get_token(user_id, "zapier")
+    if not token:
+        logger.info(
+            "Zapier token missing",
+            extra={"user_id": user_id, "platform": "zapier"},
+        )
+        return {"status": "error", "message": "Missing token for zapier"}
+
+    logger.info(
+        "Zapier trigger_zap",
+        extra={"payload": payload, "user_id": user_id},
+    )
 
     # Placeholder for actual webhook call
     # Example: await zapier_client.trigger(payload)

--- a/action_engine/auth/token_manager.py
+++ b/action_engine/auth/token_manager.py
@@ -1,17 +1,22 @@
-"""Simple in-memory token storage utilities."""
+"""Simple in-memory token storage utilities.
 
-from typing import Dict
+Tokens are stored per ``user_id`` and ``platform`` so multiple users can be
+served concurrently.  This implementation is intentionally minimal and
+non-persistent – a real deployment would use a database or external storage.
+"""
 
-# In-memory storage for tokens keyed by platform name
-_token_store: Dict[str, str] = {}
+from typing import Dict, Optional
+
+# In-memory storage: ``{user_id: {platform: token}}``
+_token_store: Dict[str, Dict[str, str]] = {}
 
 
-def get_token(platform: str) -> str | None:
-    """Retrieve a stored token for the given platform."""
-    return _token_store.get(platform)
+def get_token(user_id: str, platform: str) -> Optional[str]:
+    """Retrieve a stored token for ``user_id``/``platform``."""
+    return _token_store.get(user_id, {}).get(platform)
 
 
-def set_token(platform: str, token: str) -> None:
-    """Store the access token for the given platform."""
-    _token_store[platform] = token
+def set_token(user_id: str, platform: str, token: str) -> None:
+    """Store the access token for ``user_id``/``platform``."""
+    _token_store.setdefault(user_id, {})[platform] = token
 

--- a/action_engine/router.py
+++ b/action_engine/router.py
@@ -43,6 +43,7 @@ async def route_action(data):
     action = parse_request(request_model)
     platform = action.platform
     action_type = action.action_type
+    user_id = action.user_id
     payload = action.payload
 
     if platform == "test":
@@ -75,7 +76,7 @@ async def route_action(data):
         )
 
     try:
-        result = await action_func(payload)
+        result = await action_func(user_id, payload)
         logger.info("Adapter executed", extra={"platform": platform, "action_type": action_type})
         return JSONResponse(content={"status": "success", "result": result})
     except Exception as e:

--- a/action_engine/tests/test_adapters.py
+++ b/action_engine/tests/test_adapters.py
@@ -1,16 +1,19 @@
 import pytest
 from adapters import gmail_adapter, google_calendar_adapter, notion_adapter, zapier_adapter
+from auth import token_manager
 
 @pytest.mark.asyncio
 async def test_gmail_perform_action():
     params = {"a": 1}
-    result = await gmail_adapter.perform_action(params)
+    token_manager.set_token("u1", "gmail", "t")
+    result = await gmail_adapter.perform_action("u1", params)
     assert result == {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
 @pytest.mark.asyncio
 async def test_gmail_send_email():
     payload = {"to": "x@example.com"}
-    result = await gmail_adapter.send_email(payload)
+    token_manager.set_token("u1", "gmail", "t")
+    result = await gmail_adapter.send_email("u1", payload)
     assert result == {
         "status": "success",
         "platform": "gmail",
@@ -21,7 +24,8 @@ async def test_gmail_send_email():
 @pytest.mark.asyncio
 async def test_google_calendar_create_event():
     payload = {"title": "meeting"}
-    result = await google_calendar_adapter.create_event(payload)
+    token_manager.set_token("u1", "google_calendar", "t")
+    result = await google_calendar_adapter.create_event("u1", payload)
     assert result == {
         "status": "success",
         "platform": "google_calendar",
@@ -32,7 +36,8 @@ async def test_google_calendar_create_event():
 @pytest.mark.asyncio
 async def test_notion_create_task():
     payload = {"title": "task"}
-    result = await notion_adapter.create_task(payload)
+    token_manager.set_token("u1", "notion", "t")
+    result = await notion_adapter.create_task("u1", payload)
     assert result == {
         "status": "success",
         "platform": "notion",
@@ -43,5 +48,6 @@ async def test_notion_create_task():
 @pytest.mark.asyncio
 async def test_zapier_perform_action():
     params = {"x": 2}
-    result = await zapier_adapter.perform_action(params)
+    token_manager.set_token("u1", "zapier", "t")
+    result = await zapier_adapter.perform_action("u1", params)
     assert result == {"message": "בוצעה פעולה דרך Zapier", "params": params}

--- a/action_engine/tests/test_router.py
+++ b/action_engine/tests/test_router.py
@@ -1,5 +1,6 @@
 import importlib
 import pytest
+from auth import token_manager
 
 # Import router after fastapi stub is set up in conftest
 router = importlib.import_module("router")
@@ -10,9 +11,11 @@ def make_payload():
 @pytest.mark.asyncio
 async def test_route_gmail_success():
     payload = make_payload()
+    token_manager.set_token("u1", "gmail", "t")
     response = await router.route_action({
         "platform": "gmail",
         "action_type": "perform_action",
+        "user_id": "u1",
         "payload": payload,
     })
     assert response.status_code == 200
@@ -27,9 +30,11 @@ async def test_route_gmail_success():
 @pytest.mark.asyncio
 async def test_route_google_calendar_success():
     payload = make_payload()
+    token_manager.set_token("u1", "google_calendar", "t")
     response = await router.route_action({
         "platform": "google_calendar",
         "action_type": "create_event",
+        "user_id": "u1",
         "payload": payload,
     })
     assert response.status_code == 200
@@ -46,9 +51,11 @@ async def test_route_google_calendar_success():
 @pytest.mark.asyncio
 async def test_route_notion_success():
     payload = make_payload()
+    token_manager.set_token("u1", "notion", "t")
     response = await router.route_action({
         "platform": "notion",
         "action_type": "create_task",
+        "user_id": "u1",
         "payload": payload,
     })
     assert response.status_code == 200
@@ -65,9 +72,11 @@ async def test_route_notion_success():
 @pytest.mark.asyncio
 async def test_route_zapier_success():
     payload = make_payload()
+    token_manager.set_token("u1", "zapier", "t")
     response = await router.route_action({
         "platform": "zapier",
         "action_type": "perform_action",
+        "user_id": "u1",
         "payload": payload,
     })
     assert response.status_code == 200
@@ -83,6 +92,7 @@ async def test_route_zapier_success():
 async def test_missing_platform_error():
     response = await router.route_action({
         "action_type": "perform_action",
+        "user_id": "u1",
         "payload": {},
     })
     assert response.status_code == 400
@@ -93,6 +103,7 @@ async def test_unknown_action_error():
     response = await router.route_action({
         "platform": "gmail",
         "action_type": "unknown",
+        "user_id": "u1",
         "payload": {},
     })
     assert response.status_code == 400

--- a/action_engine/tests/test_token_manager.py
+++ b/action_engine/tests/test_token_manager.py
@@ -1,0 +1,10 @@
+import pytest
+from auth import token_manager
+
+
+def test_token_storage_per_user():
+    token_manager.set_token("user1", "gmail", "tok1")
+    token_manager.set_token("user2", "gmail", "tok2")
+    assert token_manager.get_token("user1", "gmail") == "tok1"
+    assert token_manager.get_token("user2", "gmail") == "tok2"
+    assert token_manager.get_token("user3", "gmail") is None

--- a/action_engine/validator.py
+++ b/action_engine/validator.py
@@ -11,6 +11,7 @@ class ActionRequest(BaseModel):
 
     action_type: str
     platform: str
+    user_id: str
     payload: Dict[str, Any]
 
 
@@ -33,7 +34,7 @@ def validate_request(data: Dict[str, Any]) -> ActionRequest:
         If required fields are missing or parsing fails.
     """
 
-    required_fields = ["action_type", "platform", "payload"]
+    required_fields = ["action_type", "platform", "user_id", "payload"]
     for field in required_fields:
         if field not in data or data[field] is None:
             # Error message in Hebrew so tests can verify localised responses


### PR DESCRIPTION
## Summary
- support user-scoped tokens in `token_manager`
- wire `user_id` through ActionModel and router
- update Gmail, Google Calendar, Notion and Zapier adapters to fetch tokens per user
- update validation to require `user_id`
- adjust tests and add new token manager tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816675d65c832e893ce9de178ba5c3