### PR TITLE
Add token save API

### DIFF
--- a/action_engine/main.py
+++ b/action_engine/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
 from router import route_action
 from validator import ActionRequest
 
@@ -10,6 +11,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from action_engine.logging.logger import get_logger
+from auth import token_manager
 
 app = FastAPI()
 logger = get_logger(__name__)
@@ -21,3 +23,20 @@ async def perform_action(request: ActionRequest):
     response = await route_action(request.dict())
     logger.info("Action request completed")
     return response
+
+
+@app.post("/auth/token")
+async def save_token(data: dict):
+    """Store an access token for a user/platform."""
+    user_id = data.get("user_id")
+    platform = data.get("platform")
+    access_token = data.get("access_token")
+
+    if not all(isinstance(v, str) for v in (user_id, platform, access_token)):
+        detail = "Invalid token payload: 'user_id', 'platform' and 'access_token' are required"
+        logger.info("Token validation error", extra={"user_id": user_id, "platform": platform})
+        return JSONResponse(content={"error": detail}, status_code=400)
+
+    token_manager.set_token(user_id, platform, access_token)
+    logger.info("Token stored", extra={"user_id": user_id, "platform": platform})
+    return JSONResponse(content={"status": "ok"})

--- a/action_engine/tests/test_auth.py
+++ b/action_engine/tests/test_auth.py
@@ -1,0 +1,25 @@
+import importlib
+import pytest
+
+from auth import token_manager
+
+
+# Import main after FastAPI stubs are set up in conftest
+main = importlib.import_module("main")
+
+
+@pytest.mark.asyncio
+async def test_save_token_success():
+    payload = {"user_id": "u1", "platform": "gmail", "access_token": "tok"}
+    response = await main.save_token(payload)
+    assert response.status_code == 200
+    assert response.content == {"status": "ok"}
+    assert token_manager.get_token("u1", "gmail") == "tok"
+
+
+@pytest.mark.asyncio
+async def test_save_token_validation_error():
+    payload = {"user_id": "u1", "platform": "gmail"}  # missing access_token
+    response = await main.save_token(payload)
+    assert response.status_code == 400
+    assert "Invalid token payload" in response.content["error"]


### PR DESCRIPTION
## Summary
- expose `/auth/token` endpoint in `main.py`
- store tokens via token manager and validate fields
- log token saves
- test token saving in new `test_auth`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816867aaf4832e9305819499fc33e6