### PR TITLE
Add request ID logging middleware

### DIFF
--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from action_engine.logging.logger import get_logger
+from action_engine.logging.logger import get_logger, get_request_id
 from auth.token_manager import get_token
 
 logger = get_logger(__name__)
@@ -17,13 +17,13 @@ async def perform_action(user_id: str, params: dict):
     if not token:
         logger.info(
             "Gmail token missing",
-            extra={"user_id": user_id, "platform": "gmail"},
+            extra={"user_id": user_id, "platform": "gmail", "request_id": get_request_id()},
         )
         return {"status": "error", "message": "Missing token for gmail"}
 
     logger.info(
         "Gmail perform_action invoked",
-        extra={"params": params, "user_id": user_id},
+        extra={"params": params, "user_id": user_id, "request_id": get_request_id()},
     )
     return {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
@@ -39,13 +39,13 @@ async def send_email(user_id: str, payload: dict) -> dict:
     if not token:
         logger.info(
             "Gmail token missing",
-            extra={"user_id": user_id, "platform": "gmail"},
+            extra={"user_id": user_id, "platform": "gmail", "request_id": get_request_id()},
         )
         return {"status": "error", "message": "Missing token for gmail"}
 
     logger.info(
         "Gmail send_email",
-        extra={"payload": payload, "user_id": user_id},
+        extra={"payload": payload, "user_id": user_id, "request_id": get_request_id()},
     )
 
     return {

--- a/action_engine/adapters/google_calendar_adapter.py
+++ b/action_engine/adapters/google_calendar_adapter.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from action_engine.logging.logger import get_logger
+from action_engine.logging.logger import get_logger, get_request_id
 from auth.token_manager import get_token
 
 logger = get_logger(__name__)
@@ -21,13 +21,13 @@ async def create_event(user_id: str, payload: dict):
     if not token:
         logger.info(
             "Google Calendar token missing",
-            extra={"user_id": user_id, "platform": "google_calendar"},
+            extra={"user_id": user_id, "platform": "google_calendar", "request_id": get_request_id()},
         )
         return {"status": "error", "message": "Missing token for google_calendar"}
 
     logger.info(
         "Google Calendar create_event",
-        extra={"payload": payload, "user_id": user_id},
+        extra={"payload": payload, "user_id": user_id, "request_id": get_request_id()},
     )
 
     # Placeholder for Google Calendar API integration

--- a/action_engine/adapters/notion_adapter.py
+++ b/action_engine/adapters/notion_adapter.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from action_engine.logging.logger import get_logger
+from action_engine.logging.logger import get_logger, get_request_id
 from auth.token_manager import get_token
 
 logger = get_logger(__name__)
@@ -18,13 +18,13 @@ async def create_task(user_id: str, payload: dict):
     if not token:
         logger.info(
             "Notion token missing",
-            extra={"user_id": user_id, "platform": "notion"},
+            extra={"user_id": user_id, "platform": "notion", "request_id": get_request_id()},
         )
         return {"status": "error", "message": "Missing token for notion"}
 
     logger.info(
         "Notion create_task",
-        extra={"payload": payload, "user_id": user_id},
+        extra={"payload": payload, "user_id": user_id, "request_id": get_request_id()},
     )
 
     # Placeholder for Notion API integration

--- a/action_engine/adapters/zapier_adapter.py
+++ b/action_engine/adapters/zapier_adapter.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from action_engine.logging.logger import get_logger
+from action_engine.logging.logger import get_logger, get_request_id
 from auth.token_manager import get_token
 
 logger = get_logger(__name__)
@@ -17,13 +17,13 @@ async def perform_action(user_id: str, params: dict):
     if not token:
         logger.info(
             "Zapier token missing",
-            extra={"user_id": user_id, "platform": "zapier"},
+            extra={"user_id": user_id, "platform": "zapier", "request_id": get_request_id()},
         )
         return {"status": "error", "message": "Missing token for zapier"}
 
     logger.info(
         "Zapier perform_action",
-        extra={"params": params, "user_id": user_id},
+        extra={"params": params, "user_id": user_id, "request_id": get_request_id()},
     )
     return {"message": "בוצעה פעולה דרך Zapier", "params": params}
 
@@ -34,13 +34,13 @@ async def trigger_zap(user_id: str, payload: dict) -> dict:
     if not token:
         logger.info(
             "Zapier token missing",
-            extra={"user_id": user_id, "platform": "zapier"},
+            extra={"user_id": user_id, "platform": "zapier", "request_id": get_request_id()},
         )
         return {"status": "error", "message": "Missing token for zapier"}
 
     logger.info(
         "Zapier trigger_zap",
-        extra={"payload": payload, "user_id": user_id},
+        extra={"payload": payload, "user_id": user_id, "request_id": get_request_id()},
     )
 
     # Placeholder for actual webhook call

--- a/action_engine/logging/logger.py
+++ b/action_engine/logging/logger.py
@@ -1,6 +1,20 @@
 import json
 import logging
 from typing import Any
+from datetime import datetime
+import contextvars
+import uuid
+
+# Context variable storing the current request ID
+request_id_ctx_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id",
+    default=None,
+)
+
+
+def get_request_id() -> str | None:
+    """Return the request ID for the current context if available."""
+    return request_id_ctx_var.get()
 
 
 class JsonFormatter(logging.Formatter):
@@ -11,9 +25,12 @@ class JsonFormatter(logging.Formatter):
             "level": record.levelname,
             "name": record.name,
             "message": record.getMessage(),
+            "time": datetime.utcnow().isoformat(),
         }
         if record.exc_info:
             log_record["exception"] = self.formatException(record.exc_info)
+        if hasattr(record, "request_id") and record.request_id is not None:
+            log_record["request_id"] = record.request_id
         return json.dumps(log_record)
 
 
@@ -29,3 +46,20 @@ def get_logger(name: str) -> logging.Logger:
         logger.setLevel(logging.INFO)
         logger.propagate = False
     return logger
+
+
+class RequestIdMiddleware:
+    """Simple ASGI middleware that assigns a UUID request ID for each request."""
+
+    def __init__(self, app: Any):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):  # pragma: no cover - simple middleware
+        if scope.get("type") == "http":
+            token = request_id_ctx_var.set(str(uuid.uuid4()))
+            try:
+                await self.app(scope, receive, send)
+            finally:
+                request_id_ctx_var.reset(token)
+        else:
+            await self.app(scope, receive, send)

--- a/action_engine/main.py
+++ b/action_engine/main.py
@@ -10,18 +10,24 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from action_engine.logging.logger import get_logger
+from action_engine.logging.logger import (
+    get_logger,
+    get_request_id,
+    RequestIdMiddleware,
+)
 from auth import token_manager
 
 app = FastAPI()
+app.add_middleware(RequestIdMiddleware)
 logger = get_logger(__name__)
 
 
 @app.post("/perform_action")
 async def perform_action(request: ActionRequest):
-    logger.info("Received action request")
+    request_id = get_request_id()
+    logger.info("Received action request", extra={"request_id": request_id})
     response = await route_action(request.dict())
-    logger.info("Action request completed")
+    logger.info("Action request completed", extra={"request_id": request_id})
     return response
 
 
@@ -34,9 +40,15 @@ async def save_token(data: dict):
 
     if not all(isinstance(v, str) for v in (user_id, platform, access_token)):
         detail = "Invalid token payload: 'user_id', 'platform' and 'access_token' are required"
-        logger.info("Token validation error", extra={"user_id": user_id, "platform": platform})
+        logger.info(
+            "Token validation error",
+            extra={"user_id": user_id, "platform": platform, "request_id": get_request_id()},
+        )
         return JSONResponse(content={"error": detail}, status_code=400)
 
     token_manager.set_token(user_id, platform, access_token)
-    logger.info("Token stored", extra={"user_id": user_id, "platform": platform})
+    logger.info(
+        "Token stored",
+        extra={"user_id": user_id, "platform": platform, "request_id": get_request_id()},
+    )
     return JSONResponse(content={"status": "ok"})

--- a/action_engine/tests/conftest.py
+++ b/action_engine/tests/conftest.py
@@ -28,10 +28,16 @@ fastapi.HTTPException = DummyHTTPException
 
 # Minimal FastAPI stub so modules importing FastAPI don't fail
 class DummyFastAPI:
+    def __init__(self):
+        self.middlewares = []
+
     def post(self, path):
         def decorator(func):
             return func
         return decorator
+
+    def add_middleware(self, middleware_class, **options):
+        self.middlewares.append((middleware_class, options))
 
 fastapi.FastAPI = DummyFastAPI
 

--- a/action_engine/tests/test_logging.py
+++ b/action_engine/tests/test_logging.py
@@ -1,0 +1,34 @@
+import io
+import json
+import logging
+from action_engine.logging.logger import JsonFormatter
+
+
+def create_logger():
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(JsonFormatter())
+    logger = logging.getLogger('test_logger')
+    logger.handlers = []
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger, stream
+
+
+def test_formatter_includes_timestamp_and_request_id():
+    logger, stream = create_logger()
+    logger.info('msg', extra={'request_id': '123'})
+    data = json.loads(stream.getvalue())
+    assert data['message'] == 'msg'
+    assert 'time' in data
+    assert data['request_id'] == '123'
+
+
+def test_formatter_without_request_id():
+    logger, stream = create_logger()
+    logger.info('hello')
+    data = json.loads(stream.getvalue())
+    assert data['message'] == 'hello'
+    assert 'time' in data
+    assert 'request_id' not in data
+


### PR DESCRIPTION
## Summary
- extend JsonFormatter with timestamps and optional request_id
- attach request_id context via RequestIdMiddleware
- propagate request_id in all logging calls
- adapt DummyFastAPI to allow middleware
- test JsonFormatter fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816bba996c832e90acc23368783714