### PR TITLE
Switch token storage to Redis

### DIFF
--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 
 async def perform_action(user_id: str, params: dict):
     """Mock action execution for Gmail."""
-    token = get_token(user_id, "gmail")
+    token = await get_token(user_id, "gmail")
     if not token:
         logger.info(
             "Gmail token missing",
@@ -35,7 +35,7 @@ async def send_email(user_id: str, payload: dict) -> dict:
     simply echoes back the provided payload.
     """
     # Basic logging for action invocation
-    token = get_token(user_id, "gmail")
+    token = await get_token(user_id, "gmail")
     if not token:
         logger.info(
             "Gmail token missing",

--- a/action_engine/adapters/google_calendar_adapter.py
+++ b/action_engine/adapters/google_calendar_adapter.py
@@ -17,7 +17,7 @@ async def create_event(user_id: str, payload: dict):
     יוצר אירוע ביומן Google (מימוש ראשוני, דמיוני).
     """
     # תיעוד / הדמיה
-    token = get_token(user_id, "google_calendar")
+    token = await get_token(user_id, "google_calendar")
     if not token:
         logger.info(
             "Google Calendar token missing",

--- a/action_engine/adapters/notion_adapter.py
+++ b/action_engine/adapters/notion_adapter.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 async def create_task(user_id: str, payload: dict):
     """Create a task in Notion (mocked)."""
     # Simulate interaction with Notion API
-    token = get_token(user_id, "notion")
+    token = await get_token(user_id, "notion")
     if not token:
         logger.info(
             "Notion token missing",

--- a/action_engine/adapters/zapier_adapter.py
+++ b/action_engine/adapters/zapier_adapter.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 
 async def perform_action(user_id: str, params: dict):
     """Mock integration with Zapier Webhook / Trigger."""
-    token = get_token(user_id, "zapier")
+    token = await get_token(user_id, "zapier")
     if not token:
         logger.info(
             "Zapier token missing",
@@ -30,7 +30,7 @@ async def perform_action(user_id: str, params: dict):
 
 async def trigger_zap(user_id: str, payload: dict) -> dict:
     """Trigger a Zap via webhook (mocked)."""
-    token = get_token(user_id, "zapier")
+    token = await get_token(user_id, "zapier")
     if not token:
         logger.info(
             "Zapier token missing",

--- a/action_engine/main.py
+++ b/action_engine/main.py
@@ -37,6 +37,6 @@ async def save_token(data: dict):
         logger.info("Token validation error", extra={"user_id": user_id, "platform": platform})
         return JSONResponse(content={"error": detail}, status_code=400)
 
-    token_manager.set_token(user_id, platform, access_token)
+    await token_manager.set_token(user_id, platform, access_token)
     logger.info("Token stored", extra={"user_id": user_id, "platform": platform})
     return JSONResponse(content={"status": "ok"})

--- a/action_engine/tests/test_adapters.py
+++ b/action_engine/tests/test_adapters.py
@@ -5,14 +5,14 @@ from auth import token_manager
 @pytest.mark.asyncio
 async def test_gmail_perform_action():
     params = {"a": 1}
-    token_manager.set_token("u1", "gmail", "t")
+    await token_manager.set_token("u1", "gmail", "t")
     result = await gmail_adapter.perform_action("u1", params)
     assert result == {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
 @pytest.mark.asyncio
 async def test_gmail_send_email():
     payload = {"to": "x@example.com"}
-    token_manager.set_token("u1", "gmail", "t")
+    await token_manager.set_token("u1", "gmail", "t")
     result = await gmail_adapter.send_email("u1", payload)
     assert result == {
         "status": "success",
@@ -24,7 +24,7 @@ async def test_gmail_send_email():
 @pytest.mark.asyncio
 async def test_google_calendar_create_event():
     payload = {"title": "meeting"}
-    token_manager.set_token("u1", "google_calendar", "t")
+    await token_manager.set_token("u1", "google_calendar", "t")
     result = await google_calendar_adapter.create_event("u1", payload)
     assert result == {
         "status": "success",
@@ -36,7 +36,7 @@ async def test_google_calendar_create_event():
 @pytest.mark.asyncio
 async def test_notion_create_task():
     payload = {"title": "task"}
-    token_manager.set_token("u1", "notion", "t")
+    await token_manager.set_token("u1", "notion", "t")
     result = await notion_adapter.create_task("u1", payload)
     assert result == {
         "status": "success",
@@ -48,6 +48,6 @@ async def test_notion_create_task():
 @pytest.mark.asyncio
 async def test_zapier_perform_action():
     params = {"x": 2}
-    token_manager.set_token("u1", "zapier", "t")
+    await token_manager.set_token("u1", "zapier", "t")
     result = await zapier_adapter.perform_action("u1", params)
     assert result == {"message": "בוצעה פעולה דרך Zapier", "params": params}

--- a/action_engine/tests/test_auth.py
+++ b/action_engine/tests/test_auth.py
@@ -14,7 +14,7 @@ async def test_save_token_success():
     response = await main.save_token(payload)
     assert response.status_code == 200
     assert response.content == {"status": "ok"}
-    assert token_manager.get_token("u1", "gmail") == "tok"
+    assert await token_manager.get_token("u1", "gmail") == "tok"
 
 
 @pytest.mark.asyncio

--- a/action_engine/tests/test_router.py
+++ b/action_engine/tests/test_router.py
@@ -11,7 +11,7 @@ def make_payload():
 @pytest.mark.asyncio
 async def test_route_gmail_success():
     payload = make_payload()
-    token_manager.set_token("u1", "gmail", "t")
+    await token_manager.set_token("u1", "gmail", "t")
     response = await router.route_action({
         "platform": "gmail",
         "action_type": "perform_action",
@@ -30,7 +30,7 @@ async def test_route_gmail_success():
 @pytest.mark.asyncio
 async def test_route_google_calendar_success():
     payload = make_payload()
-    token_manager.set_token("u1", "google_calendar", "t")
+    await token_manager.set_token("u1", "google_calendar", "t")
     response = await router.route_action({
         "platform": "google_calendar",
         "action_type": "create_event",
@@ -51,7 +51,7 @@ async def test_route_google_calendar_success():
 @pytest.mark.asyncio
 async def test_route_notion_success():
     payload = make_payload()
-    token_manager.set_token("u1", "notion", "t")
+    await token_manager.set_token("u1", "notion", "t")
     response = await router.route_action({
         "platform": "notion",
         "action_type": "create_task",
@@ -72,7 +72,7 @@ async def test_route_notion_success():
 @pytest.mark.asyncio
 async def test_route_zapier_success():
     payload = make_payload()
-    token_manager.set_token("u1", "zapier", "t")
+    await token_manager.set_token("u1", "zapier", "t")
     response = await router.route_action({
         "platform": "zapier",
         "action_type": "perform_action",

--- a/action_engine/tests/test_token_manager.py
+++ b/action_engine/tests/test_token_manager.py
@@ -2,9 +2,10 @@ import pytest
 from auth import token_manager
 
 
-def test_token_storage_per_user():
-    token_manager.set_token("user1", "gmail", "tok1")
-    token_manager.set_token("user2", "gmail", "tok2")
-    assert token_manager.get_token("user1", "gmail") == "tok1"
-    assert token_manager.get_token("user2", "gmail") == "tok2"
-    assert token_manager.get_token("user3", "gmail") is None
+@pytest.mark.asyncio
+async def test_token_storage_per_user():
+    await token_manager.set_token("user1", "gmail", "tok1")
+    await token_manager.set_token("user2", "gmail", "tok2")
+    assert await token_manager.get_token("user1", "gmail") == "tok1"
+    assert await token_manager.get_token("user2", "gmail") == "tok2"
+    assert await token_manager.get_token("user3", "gmail") is None


### PR DESCRIPTION
## Summary
- swap in-memory token store for Redis client
- make token_manager functions async
- update adapters and main to await Redis-backed token lookups
- stub asyncio Redis for tests and adjust pytest harness
- update unit tests for async token manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816bb8b8d8832e88747e2203d8dd89