### PR TITLE
Add API key header validation

### DIFF
--- a/action_engine/main.py
+++ b/action_engine/main.py
@@ -1,10 +1,11 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.responses import JSONResponse
 from router import route_action
 from validator import ActionRequest
 
 import sys
 from pathlib import Path
+import os
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
@@ -16,9 +17,22 @@ from auth import token_manager
 app = FastAPI()
 logger = get_logger(__name__)
 
+API_KEY = os.getenv("API_KEY")
+
+
+def verify_api_key(x_api_key: str | None) -> None:
+    """Validate the provided ``X-API-Key`` header."""
+    if API_KEY and x_api_key != API_KEY:
+        logger.info("Invalid API key", extra={"provided": x_api_key})
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
 
 @app.post("/perform_action")
-async def perform_action(request: ActionRequest):
+async def perform_action(request: ActionRequest, x_api_key: str = Header(None)):
+    try:
+        verify_api_key(x_api_key)
+    except HTTPException as exc:
+        return JSONResponse(content={"error": exc.detail}, status_code=exc.status_code)
     logger.info("Received action request")
     response = await route_action(request.dict())
     logger.info("Action request completed")
@@ -26,8 +40,12 @@ async def perform_action(request: ActionRequest):
 
 
 @app.post("/auth/token")
-async def save_token(data: dict):
+async def save_token(data: dict, x_api_key: str = Header(None)):
     """Store an access token for a user/platform."""
+    try:
+        verify_api_key(x_api_key)
+    except HTTPException as exc:
+        return JSONResponse(content={"error": exc.detail}, status_code=exc.status_code)
     user_id = data.get("user_id")
     platform = data.get("platform")
     access_token = data.get("access_token")

--- a/action_engine/tests/conftest.py
+++ b/action_engine/tests/conftest.py
@@ -26,6 +26,12 @@ fastapi = types.ModuleType("fastapi")
 fastapi.responses = a_responses
 fastapi.HTTPException = DummyHTTPException
 
+# Provide minimal implementations of common FastAPI utilities
+def Header(default=None):
+    return default
+
+fastapi.Header = Header
+
 # Minimal FastAPI stub so modules importing FastAPI don't fail
 class DummyFastAPI:
     def post(self, path):

--- a/action_engine/tests/test_auth.py
+++ b/action_engine/tests/test_auth.py
@@ -1,17 +1,19 @@
 import importlib
+import os
 import pytest
 
 from auth import token_manager
 
 
-# Import main after FastAPI stubs are set up in conftest
+# Import main after setting API_KEY and FastAPI stubs
+os.environ["API_KEY"] = "test-key"
 main = importlib.import_module("main")
 
 
 @pytest.mark.asyncio
 async def test_save_token_success():
     payload = {"user_id": "u1", "platform": "gmail", "access_token": "tok"}
-    response = await main.save_token(payload)
+    response = await main.save_token(payload, x_api_key="test-key")
     assert response.status_code == 200
     assert response.content == {"status": "ok"}
     assert token_manager.get_token("u1", "gmail") == "tok"
@@ -20,6 +22,20 @@ async def test_save_token_success():
 @pytest.mark.asyncio
 async def test_save_token_validation_error():
     payload = {"user_id": "u1", "platform": "gmail"}  # missing access_token
-    response = await main.save_token(payload)
+    response = await main.save_token(payload, x_api_key="test-key")
     assert response.status_code == 400
     assert "Invalid token payload" in response.content["error"]
+
+
+@pytest.mark.asyncio
+async def test_save_token_missing_key():
+    payload = {"user_id": "u1", "platform": "gmail", "access_token": "tok"}
+    response = await main.save_token(payload)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_save_token_invalid_key():
+    payload = {"user_id": "u1", "platform": "gmail", "access_token": "tok"}
+    response = await main.save_token(payload, x_api_key="bad")
+    assert response.status_code == 401

--- a/action_engine/tests/test_main_api_key.py
+++ b/action_engine/tests/test_main_api_key.py
@@ -1,0 +1,31 @@
+import importlib
+import os
+import pytest
+
+from validator import ActionRequest
+
+# Set API key before importing main
+os.environ["API_KEY"] = "test-key"
+main = importlib.import_module("main")
+
+
+@pytest.mark.asyncio
+async def test_perform_action_missing_key():
+    req = ActionRequest(action_type="perform_action", platform="test", user_id="u1", payload={})
+    response = await main.perform_action(req)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_perform_action_invalid_key():
+    req = ActionRequest(action_type="perform_action", platform="test", user_id="u1", payload={})
+    response = await main.perform_action(req, x_api_key="bad")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_perform_action_success_with_key():
+    req = ActionRequest(action_type="perform_action", platform="test", user_id="u1", payload={})
+    response = await main.perform_action(req, x_api_key="test-key")
+    assert response.status_code == 200
+    assert response.content == {"message": "המערכת עובדת 🎯"}


### PR DESCRIPTION
## Summary
- secure endpoints with an API key
- add minimal Header stub for tests
- update token tests for API key checks
- add tests covering perform_action API key handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68816bb8b3a8832ea5ed5a7a26e3ed48