### PR TITLE
Refactor for env config and Redis enforcement

### DIFF
--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -1,11 +1,33 @@
 from action_engine.logging.logger import get_logger, get_request_id
 from action_engine.auth import token_manager
+from fastapi import HTTPException
+from pydantic import BaseModel
 
 logger = get_logger(__name__)
 
 
+class GmailPerformActionPayload(BaseModel):
+    key: str
+
+
+class GmailSendEmailPayload(BaseModel):
+    to: str
+
+
+def _validate(payload: dict, model: type[BaseModel]) -> BaseModel:
+    try:
+        obj = model(**payload)
+    except Exception as exc:  # pragma: no cover - simple validation
+        raise HTTPException(status_code=422, detail=str(exc))
+    for field in model.__annotations__:
+        if getattr(obj, field, None) is None:
+            raise HTTPException(status_code=422, detail=f"Missing field: {field}")
+    return obj
+
+
 async def perform_action(user_id: str, params: dict):
     """Mock action execution for Gmail."""
+    _validate(params, GmailPerformActionPayload)
     token = await token_manager.get_token(user_id, "gmail")
     if not token:
         logger.info(
@@ -27,6 +49,7 @@ async def send_email(user_id: str, payload: dict) -> dict:
     This function currently mocks the interaction with the Gmail API and
     simply echoes back the provided payload.
     """
+    _validate(payload, GmailSendEmailPayload)
     # Basic logging for action invocation
     token = await token_manager.get_token(user_id, "gmail")
     if not token:

--- a/action_engine/adapters/notion_adapter.py
+++ b/action_engine/adapters/notion_adapter.py
@@ -1,12 +1,27 @@
 from action_engine.logging.logger import get_logger, get_request_id
 from action_engine.auth import token_manager
+from fastapi import HTTPException
+from pydantic import BaseModel
 
 logger = get_logger(__name__)
+
+
+class CreateTaskPayload(BaseModel):
+    title: str
+
+
+def _validate(payload: dict, model: type[BaseModel]) -> BaseModel:
+    obj = model(**payload)
+    for field in model.__annotations__:
+        if getattr(obj, field, None) is None:
+            raise HTTPException(status_code=422, detail=f"Missing field: {field}")
+    return obj
 
 
 async def create_task(user_id: str, payload: dict):
     """Create a task in Notion (mocked)."""
     # Simulate interaction with Notion API
+    _validate(payload, CreateTaskPayload)
     token = await token_manager.get_token(user_id, "notion")
     if not token:
         logger.info(

--- a/action_engine/adapters/zapier_adapter.py
+++ b/action_engine/adapters/zapier_adapter.py
@@ -1,11 +1,26 @@
 from action_engine.logging.logger import get_logger, get_request_id
 from action_engine.auth import token_manager
+from fastapi import HTTPException
+from pydantic import BaseModel
 
 logger = get_logger(__name__)
 
 
+class PerformActionPayload(BaseModel):
+    x: int
+
+
+def _validate(payload: dict, model: type[BaseModel]) -> BaseModel:
+    obj = model(**payload)
+    for field in model.__annotations__:
+        if getattr(obj, field, None) is None:
+            raise HTTPException(status_code=422, detail=f"Missing field: {field}")
+    return obj
+
+
 async def perform_action(user_id: str, params: dict):
     """Mock integration with Zapier Webhook / Trigger."""
+    _validate(params, PerformActionPayload)
     token = await token_manager.get_token(user_id, "zapier")
     if not token:
         logger.info(
@@ -23,6 +38,7 @@ async def perform_action(user_id: str, params: dict):
 
 async def trigger_zap(user_id: str, payload: dict) -> dict:
     """Trigger a Zap via webhook (mocked)."""
+    _validate(payload, PerformActionPayload)
     token = await token_manager.get_token(user_id, "zapier")
     if not token:
         logger.info(

--- a/action_engine/config.py
+++ b/action_engine/config.py
@@ -1,0 +1,14 @@
+import os
+from pathlib import Path
+
+# Load variables from .env if present
+_env_path = Path(__file__).resolve().parent.parent / '.env'
+if _env_path.exists():
+    with _env_path.open() as f:
+        for line in f:
+            if '=' in line and not line.startswith('#'):
+                key, value = line.strip().split('=', 1)
+                os.environ.setdefault(key, value)
+
+API_KEY = os.getenv('API_KEY', 'testkey')
+REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379')

--- a/action_engine/main.py
+++ b/action_engine/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException, Header
 from fastapi.responses import JSONResponse
 from action_engine.router import route_action
 from action_engine.validator import ActionRequest
+from action_engine.config import API_KEY
 
 from action_engine.logging.logger import (
     get_logger,
@@ -9,8 +10,6 @@ from action_engine.logging.logger import (
     RequestIdMiddleware,
 )
 from action_engine.auth import token_manager
-
-API_KEY = "testkey"
 
 app = FastAPI()
 app.add_middleware(RequestIdMiddleware)

--- a/action_engine/router.py
+++ b/action_engine/router.py
@@ -82,6 +82,9 @@ async def route_action(data):
             extra={"platform": platform, "action_type": action_type, "request_id": request_id},
         )
         return JSONResponse(content={"status": "success", "result": result})
+    except HTTPException as exc:
+        logger.info("Execution error", extra={"error": exc.detail, "request_id": request_id})
+        return JSONResponse(content={"error": exc.detail}, status_code=exc.status_code)
     except Exception as e:
         logger.info("Execution error", extra={"error": str(e), "request_id": request_id})
         return JSONResponse(content={"status": "error", "message": str(e)}, status_code=500)

--- a/action_engine/tests/conftest.py
+++ b/action_engine/tests/conftest.py
@@ -90,3 +90,17 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "asyncio: mark test to run asynchronously using asyncio.run"
     )
+
+
+class DummyRedis:
+    def __init__(self):
+        self.store = {}
+
+    async def ping(self):  # pragma: no cover - simple stub
+        return True
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value):
+        self.store[key] = value

--- a/action_engine/tests/test_adapters.py
+++ b/action_engine/tests/test_adapters.py
@@ -1,16 +1,27 @@
 import pytest
 from action_engine.adapters import gmail_adapter, google_calendar_adapter, notion_adapter, zapier_adapter
 from action_engine.auth import token_manager
+from action_engine.tests.conftest import DummyRedis
 
 @pytest.mark.asyncio
 async def test_gmail_perform_action():
-    params = {"a": 1}
+    await token_manager.init_redis(DummyRedis())
+    params = {"key": "value"}
     await token_manager.set_token("u1", "gmail", "t")
     result = await gmail_adapter.perform_action("u1", params)
     assert result == {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
+
+@pytest.mark.asyncio
+async def test_gmail_perform_action_validation_error():
+    await token_manager.init_redis(DummyRedis())
+    await token_manager.set_token("u1", "gmail", "t")
+    with pytest.raises(Exception):
+        await gmail_adapter.perform_action("u1", {})
+
 @pytest.mark.asyncio
 async def test_gmail_send_email():
+    await token_manager.init_redis(DummyRedis())
     payload = {"to": "x@example.com"}
     await token_manager.set_token("u1", "gmail", "t")
     result = await gmail_adapter.send_email("u1", payload)
@@ -21,8 +32,17 @@ async def test_gmail_send_email():
         "data": payload,
     }
 
+
+@pytest.mark.asyncio
+async def test_gmail_send_email_validation_error():
+    await token_manager.init_redis(DummyRedis())
+    await token_manager.set_token("u1", "gmail", "t")
+    with pytest.raises(Exception):
+        await gmail_adapter.send_email("u1", {})
+
 @pytest.mark.asyncio
 async def test_google_calendar_create_event():
+    await token_manager.init_redis(DummyRedis())
     payload = {"title": "meeting"}
     await token_manager.set_token("u1", "google_calendar", "t")
     result = await google_calendar_adapter.create_event("u1", payload)
@@ -33,8 +53,17 @@ async def test_google_calendar_create_event():
         "data": payload,
     }
 
+
+@pytest.mark.asyncio
+async def test_google_calendar_create_event_validation_error():
+    await token_manager.init_redis(DummyRedis())
+    await token_manager.set_token("u1", "google_calendar", "t")
+    with pytest.raises(Exception):
+        await google_calendar_adapter.create_event("u1", {})
+
 @pytest.mark.asyncio
 async def test_notion_create_task():
+    await token_manager.init_redis(DummyRedis())
     payload = {"title": "task"}
     await token_manager.set_token("u1", "notion", "t")
     result = await notion_adapter.create_task("u1", payload)
@@ -45,9 +74,26 @@ async def test_notion_create_task():
         "data": payload,
     }
 
+
+@pytest.mark.asyncio
+async def test_notion_create_task_validation_error():
+    await token_manager.init_redis(DummyRedis())
+    await token_manager.set_token("u1", "notion", "t")
+    with pytest.raises(Exception):
+        await notion_adapter.create_task("u1", {})
+
 @pytest.mark.asyncio
 async def test_zapier_perform_action():
+    await token_manager.init_redis(DummyRedis())
     params = {"x": 2}
     await token_manager.set_token("u1", "zapier", "t")
     result = await zapier_adapter.perform_action("u1", params)
     assert result == {"message": "בוצעה פעולה דרך Zapier", "params": params}
+
+
+@pytest.mark.asyncio
+async def test_zapier_perform_action_validation_error():
+    await token_manager.init_redis(DummyRedis())
+    await token_manager.set_token("u1", "zapier", "t")
+    with pytest.raises(Exception):
+        await zapier_adapter.perform_action("u1", {})

--- a/action_engine/tests/test_auth.py
+++ b/action_engine/tests/test_auth.py
@@ -2,6 +2,7 @@ import importlib
 import pytest
 
 from action_engine.auth import token_manager
+from action_engine.tests.conftest import DummyRedis
 
 
 # Import main after FastAPI stubs are set up in conftest
@@ -13,6 +14,7 @@ API_KEY = "testkey"
 
 @pytest.mark.asyncio
 async def test_save_token_success():
+    await token_manager.init_redis(DummyRedis())
     payload = {"user_id": "u1", "platform": "gmail", "access_token": "tok"}
     response = await main.save_token(payload, x_api_key=API_KEY)
     assert response.status_code == 200
@@ -22,6 +24,7 @@ async def test_save_token_success():
 
 @pytest.mark.asyncio
 async def test_save_token_validation_error():
+    await token_manager.init_redis(DummyRedis())
     payload = {"user_id": "u1", "platform": "gmail"}  # missing access_token
     response = await main.save_token(payload, x_api_key=API_KEY)
     assert response.status_code == 400
@@ -30,6 +33,7 @@ async def test_save_token_validation_error():
 
 @pytest.mark.asyncio
 async def test_save_token_unauthorized():
+    await token_manager.init_redis(DummyRedis())
     payload = {"user_id": "u1", "platform": "gmail", "access_token": "tok"}
     response = await main.save_token(payload, x_api_key="bad")
     assert response.status_code == 401
@@ -37,6 +41,7 @@ async def test_save_token_unauthorized():
 
 @pytest.mark.asyncio
 async def test_perform_action_requires_api_key():
+    await token_manager.init_redis(DummyRedis())
     request = main.ActionRequest(
         action_type="perform_action",
         platform="test",
@@ -49,6 +54,7 @@ async def test_perform_action_requires_api_key():
 
 @pytest.mark.asyncio
 async def test_perform_action_success_with_key():
+    await token_manager.init_redis(DummyRedis())
     request = main.ActionRequest(
         action_type="perform_action",
         platform="test",

--- a/action_engine/tests/test_router.py
+++ b/action_engine/tests/test_router.py
@@ -1,16 +1,26 @@
 import importlib
 import pytest
 from action_engine.auth import token_manager
+from action_engine.tests.conftest import DummyRedis
 
 # Import router after fastapi stub is set up in conftest
 router = importlib.import_module("action_engine.router")
 
-def make_payload():
-    return {"key": "value"}
+def make_payload(platform="gmail"):
+    if platform == "gmail":
+        return {"key": "value"}
+    if platform == "google_calendar":
+        return {"title": "meeting"}
+    if platform == "notion":
+        return {"title": "task"}
+    if platform == "zapier":
+        return {"x": 1}
+    return {}
 
 @pytest.mark.asyncio
 async def test_route_gmail_success():
-    payload = make_payload()
+    await token_manager.init_redis(DummyRedis())
+    payload = make_payload("gmail")
     await token_manager.set_token("u1", "gmail", "t")
     response = await router.route_action({
         "platform": "gmail",
@@ -29,7 +39,8 @@ async def test_route_gmail_success():
 
 @pytest.mark.asyncio
 async def test_route_google_calendar_success():
-    payload = make_payload()
+    await token_manager.init_redis(DummyRedis())
+    payload = make_payload("google_calendar")
     await token_manager.set_token("u1", "google_calendar", "t")
     response = await router.route_action({
         "platform": "google_calendar",
@@ -50,7 +61,8 @@ async def test_route_google_calendar_success():
 
 @pytest.mark.asyncio
 async def test_route_notion_success():
-    payload = make_payload()
+    await token_manager.init_redis(DummyRedis())
+    payload = make_payload("notion")
     await token_manager.set_token("u1", "notion", "t")
     response = await router.route_action({
         "platform": "notion",
@@ -71,7 +83,8 @@ async def test_route_notion_success():
 
 @pytest.mark.asyncio
 async def test_route_zapier_success():
-    payload = make_payload()
+    await token_manager.init_redis(DummyRedis())
+    payload = make_payload("zapier")
     await token_manager.set_token("u1", "zapier", "t")
     response = await router.route_action({
         "platform": "zapier",
@@ -90,6 +103,7 @@ async def test_route_zapier_success():
 
 @pytest.mark.asyncio
 async def test_missing_platform_error():
+    await token_manager.init_redis(DummyRedis())
     response = await router.route_action({
         "action_type": "perform_action",
         "user_id": "u1",
@@ -100,6 +114,7 @@ async def test_missing_platform_error():
 
 @pytest.mark.asyncio
 async def test_unknown_action_error():
+    await token_manager.init_redis(DummyRedis())
     response = await router.route_action({
         "platform": "gmail",
         "action_type": "unknown",
@@ -108,3 +123,16 @@ async def test_unknown_action_error():
     })
     assert response.status_code == 400
     assert "לא קיימת" in response.content["error"]
+
+
+@pytest.mark.asyncio
+async def test_adapter_validation_error():
+    await token_manager.init_redis(DummyRedis())
+    await token_manager.set_token("u1", "gmail", "t")
+    response = await router.route_action({
+        "platform": "gmail",
+        "action_type": "perform_action",
+        "user_id": "u1",
+        "payload": {},
+    })
+    assert response.status_code == 422

--- a/action_engine/tests/test_token_manager.py
+++ b/action_engine/tests/test_token_manager.py
@@ -1,11 +1,32 @@
 import pytest
 from action_engine.auth import token_manager
+from action_engine.tests.conftest import DummyRedis
 
 
 @pytest.mark.asyncio
 async def test_token_storage_per_user():
+    await token_manager.init_redis(DummyRedis())
     await token_manager.set_token("user1", "gmail", "tok1")
     await token_manager.set_token("user2", "gmail", "tok2")
     assert await token_manager.get_token("user1", "gmail") == "tok1"
     assert await token_manager.get_token("user2", "gmail") == "tok2"
     assert await token_manager.get_token("user3", "gmail") is None
+
+
+@pytest.mark.asyncio
+async def test_token_isolation_between_platforms():
+    await token_manager.init_redis(DummyRedis())
+    await token_manager.set_token("user1", "gmail", "tok1")
+    await token_manager.set_token("user1", "notion", "tok2")
+    assert await token_manager.get_token("user1", "gmail") == "tok1"
+    assert await token_manager.get_token("user1", "notion") == "tok2"
+
+
+@pytest.mark.asyncio
+async def test_missing_redis_raises_error(monkeypatch):
+    # Simulate redis not available
+    await token_manager.init_redis(DummyRedis())
+    monkeypatch.setattr(token_manager, "_redis_client", None)
+    monkeypatch.setattr(token_manager, "redis", None)
+    with pytest.raises(RuntimeError):
+        await token_manager.get_token("u", "gmail")


### PR DESCRIPTION
## Summary
- centralize settings in `config.py` and use env vars
- enforce Redis-only token storage and raise on failure
- validate adapter payloads via small pydantic models
- handle HTTPException from adapters in router
- mock Redis in tests and expand token manager coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881765fbca0832e8349a4be1ec882bc