### PR TITLE
Add OAuth flow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,29 @@ The currently registered platforms and actions are defined in `actions_registry.
 - **zapier**: `perform_action`
 
 Additional adapter functions (e.g. `send_email` in the Gmail adapter) can be used by calling the relevant function names via the API.
+
+## Initiating OAuth
+
+Some adapters require OAuth tokens. Use the `/auth/start` and `/auth/callback` endpoints to complete the flow:
+
+1. **Start authorization**
+
+   ```bash
+   curl -X POST http://localhost:8000/auth/start \
+        -H "X-API-Key: <your key>" \
+        -d '{"user_id": "u1", "platform": "gmail", "client_id": "id", "client_secret": "secret", "redirect_uri": "https://app/callback"}'
+   ```
+
+   The response contains `authorization_url` that the user should visit.
+
+2. **Handle the callback**
+
+   After the user authorizes the application, POST the received information to `/auth/callback`:
+
+   ```bash
+   curl -X POST http://localhost:8000/auth/callback \
+        -H "X-API-Key: <your key>" \
+        -d '{"user_id": "u1", "platform": "gmail", "client_id": "id", "client_secret": "secret", "redirect_uri": "https://app/callback", "authorization_response": "..."}'
+   ```
+
+   On success the access and refresh tokens are stored and can be retrieved by the adapters when performing actions.

--- a/action_engine/main.py
+++ b/action_engine/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, HTTPException, Header
 from fastapi.responses import JSONResponse
+import json
 from action_engine.router import route_action
 from action_engine.validator import ActionRequest
 from action_engine.config import API_KEY
@@ -10,6 +11,7 @@ from action_engine.logging.logger import (
     RequestIdMiddleware,
 )
 from action_engine.auth import token_manager
+from action_engine.auth.oauth_client import OAuthClient
 
 app = FastAPI()
 app.add_middleware(RequestIdMiddleware)
@@ -47,6 +49,97 @@ async def save_token(data: dict, x_api_key: str = Header(None)):
     await token_manager.set_token(user_id, platform, access_token)
     logger.info(
         "Token stored",
+        extra={"user_id": user_id, "platform": platform, "request_id": get_request_id()},
+    )
+    return JSONResponse(content={"status": "ok"})
+
+
+@app.post("/auth/start")
+async def start_oauth(data: dict, x_api_key: str = Header(None)):
+    """Initiate an OAuth authorization flow for a platform."""
+    if x_api_key != API_KEY:
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+    user_id = data.get("user_id")
+    platform = data.get("platform")
+    client_id = data.get("client_id")
+    client_secret = data.get("client_secret")
+    redirect_uri = data.get("redirect_uri")
+    scope = data.get("scope", "")
+
+    if not all(
+        isinstance(v, str) and v
+        for v in (user_id, platform, client_id, client_secret, redirect_uri)
+    ):
+        detail = (
+            "Invalid OAuth request: 'user_id', 'platform', 'client_id', "
+            "'client_secret' and 'redirect_uri' are required"
+        )
+        logger.info(
+            "OAuth initiation validation error",
+            extra={"user_id": user_id, "platform": platform, "request_id": get_request_id()},
+        )
+        return JSONResponse(content={"error": detail}, status_code=400)
+
+    oauth_client = OAuthClient(client_id, client_secret, redirect_uri)
+    auth_url = await oauth_client.initiate_authorization(scope)
+    logger.info(
+        "OAuth flow started",
+        extra={"user_id": user_id, "platform": platform, "request_id": get_request_id()},
+    )
+    return JSONResponse(content={"authorization_url": auth_url})
+
+
+@app.post("/auth/callback")
+async def oauth_callback(data: dict, x_api_key: str = Header(None)):
+    """Handle OAuth callback and store tokens."""
+    if x_api_key != API_KEY:
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+    user_id = data.get("user_id")
+    platform = data.get("platform")
+    authorization_response = data.get("authorization_response")
+    client_id = data.get("client_id")
+    client_secret = data.get("client_secret")
+    redirect_uri = data.get("redirect_uri")
+
+    if not all(
+        isinstance(v, str) and v
+        for v in (
+            user_id,
+            platform,
+            authorization_response,
+            client_id,
+            client_secret,
+            redirect_uri,
+        )
+    ):
+        detail = (
+            "Invalid callback payload: 'user_id', 'platform', 'authorization_response', "
+            "'client_id', 'client_secret' and 'redirect_uri' are required"
+        )
+        logger.info(
+            "OAuth callback validation error",
+            extra={"user_id": user_id, "platform": platform, "request_id": get_request_id()},
+        )
+        return JSONResponse(content={"error": detail}, status_code=400)
+
+    oauth_client = OAuthClient(client_id, client_secret, redirect_uri)
+    token_data = await oauth_client.fetch_token(authorization_response)
+
+    await token_manager.set_token(
+        user_id,
+        platform,
+        json.dumps(
+            {
+                "access_token": token_data.get("access_token"),
+                "refresh_token": token_data.get("refresh_token"),
+                "expires_in": token_data.get("expires_in"),
+            }
+        ),
+    )
+    logger.info(
+        "OAuth token stored",
         extra={"user_id": user_id, "platform": platform, "request_id": get_request_id()},
     )
     return JSONResponse(content={"status": "ok"})


### PR DESCRIPTION
## Summary
- implement `/auth/start` and `/auth/callback` endpoints
- store OAuth tokens via `token_manager`
- document OAuth flow usage
- test OAuth helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688243c17ddc832e83f5dc6ebba17192