### PR TITLE
Handle token dicts and refresh

### DIFF
--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -28,7 +28,7 @@ def _validate(payload: dict, model: type[BaseModel]) -> BaseModel:
 async def perform_action(user_id: str, params: dict):
     """Mock action execution for Gmail."""
     _validate(params, GmailPerformActionPayload)
-    token = await token_manager.get_token(user_id, "gmail")
+    token = await token_manager.get_access_token(user_id, "gmail")
     if not token:
         logger.info(
             "Gmail token missing",
@@ -51,7 +51,7 @@ async def send_email(user_id: str, payload: dict) -> dict:
     """
     _validate(payload, GmailSendEmailPayload)
     # Basic logging for action invocation
-    token = await token_manager.get_token(user_id, "gmail")
+    token = await token_manager.get_access_token(user_id, "gmail")
     if not token:
         logger.info(
             "Gmail token missing",

--- a/action_engine/adapters/google_calendar_adapter.py
+++ b/action_engine/adapters/google_calendar_adapter.py
@@ -25,7 +25,7 @@ async def create_event(user_id: str, payload: dict):
     """
     # תיעוד / הדמיה
     _validate(payload, CreateEventPayload)
-    token = await token_manager.get_token(user_id, "google_calendar")
+    token = await token_manager.get_access_token(user_id, "google_calendar")
     if not token:
         logger.info(
             "Google Calendar token missing",

--- a/action_engine/adapters/notion_adapter.py
+++ b/action_engine/adapters/notion_adapter.py
@@ -22,7 +22,7 @@ async def create_task(user_id: str, payload: dict):
     """Create a task in Notion (mocked)."""
     # Simulate interaction with Notion API
     _validate(payload, CreateTaskPayload)
-    token = await token_manager.get_token(user_id, "notion")
+    token = await token_manager.get_access_token(user_id, "notion")
     if not token:
         logger.info(
             "Notion token missing",

--- a/action_engine/adapters/zapier_adapter.py
+++ b/action_engine/adapters/zapier_adapter.py
@@ -21,7 +21,7 @@ def _validate(payload: dict, model: type[BaseModel]) -> BaseModel:
 async def perform_action(user_id: str, params: dict):
     """Mock integration with Zapier Webhook / Trigger."""
     _validate(params, PerformActionPayload)
-    token = await token_manager.get_token(user_id, "zapier")
+    token = await token_manager.get_access_token(user_id, "zapier")
     if not token:
         logger.info(
             "Zapier token missing",
@@ -39,7 +39,7 @@ async def perform_action(user_id: str, params: dict):
 async def trigger_zap(user_id: str, payload: dict) -> dict:
     """Trigger a Zap via webhook (mocked)."""
     _validate(payload, PerformActionPayload)
-    token = await token_manager.get_token(user_id, "zapier")
+    token = await token_manager.get_access_token(user_id, "zapier")
     if not token:
         logger.info(
             "Zapier token missing",

--- a/action_engine/auth/token_manager.py
+++ b/action_engine/auth/token_manager.py
@@ -1,6 +1,8 @@
 """Asynchronous token storage utilities requiring Redis."""
 
-from typing import Optional
+from typing import Optional, Dict, Any
+import json
+import time
 
 from action_engine.config import REDIS_URL
 
@@ -34,13 +36,57 @@ async def _get_redis() -> Optional["redis.Redis"]:
         raise RuntimeError("Redis server unavailable") from exc
 
 
-async def get_token(user_id: str, platform: str) -> Optional[str]:
-    """Retrieve a stored token for ``user_id``/``platform``."""
+async def get_token(user_id: str, platform: str) -> Optional[Dict[str, Any]]:
+    """Retrieve a stored token dictionary for ``user_id``/``platform``."""
     client = await _get_redis()
-    return await client.get(f"{user_id}:{platform}")
+    raw = await client.get(f"{user_id}:{platform}")
+    if raw is None:
+        return None
+    try:
+        return json.loads(raw)
+    except Exception:  # pragma: no cover - invalid json
+        return None
 
 
-async def set_token(user_id: str, platform: str, token: str) -> None:
-    """Store the access token for ``user_id``/``platform``."""
+async def set_token(user_id: str, platform: str, token_data: Dict[str, Any]) -> None:
+    """Store token information for ``user_id``/``platform``."""
     client = await _get_redis()
-    await client.set(f"{user_id}:{platform}", token)
+    await client.set(f"{user_id}:{platform}", json.dumps(token_data))
+
+
+def is_expired(token_data: Dict[str, Any]) -> bool:
+    """Return ``True`` if the token has expired."""
+    expires_at = token_data.get("expires_at")
+    if expires_at is None:
+        return False
+    return time.time() >= float(expires_at)
+
+
+async def refresh_if_needed(user_id: str, platform: str) -> Optional[Dict[str, Any]]:
+    """Refresh the stored token using its ``refresh_token`` if expired."""
+    token_data = await get_token(user_id, platform)
+    if not token_data:
+        return None
+    if not is_expired(token_data):
+        return token_data
+
+    refresh_token_value = token_data.get("refresh_token")
+    if not refresh_token_value:
+        return token_data
+
+    # Simulate token refresh. Real implementation would call provider API.
+    new_data = {
+        "access_token": f"refreshed-{refresh_token_value}",
+        "refresh_token": refresh_token_value,
+        "expires_at": time.time() + 3600,
+    }
+    await set_token(user_id, platform, new_data)
+    return new_data
+
+
+async def get_access_token(user_id: str, platform: str) -> Optional[str]:
+    """Return a valid access token, refreshing if necessary."""
+    token_data = await refresh_if_needed(user_id, platform)
+    if not token_data:
+        return None
+    return token_data.get("access_token")

--- a/action_engine/main.py
+++ b/action_engine/main.py
@@ -44,7 +44,7 @@ async def save_token(data: dict, x_api_key: str = Header(None)):
         )
         return JSONResponse(content={"error": detail}, status_code=400)
 
-    await token_manager.set_token(user_id, platform, access_token)
+    await token_manager.set_token(user_id, platform, {"access_token": access_token})
     logger.info(
         "Token stored",
         extra={"user_id": user_id, "platform": platform, "request_id": get_request_id()},

--- a/action_engine/tests/test_adapters.py
+++ b/action_engine/tests/test_adapters.py
@@ -7,7 +7,7 @@ from action_engine.tests.conftest import DummyRedis
 async def test_gmail_perform_action():
     await token_manager.init_redis(DummyRedis())
     params = {"key": "value"}
-    await token_manager.set_token("u1", "gmail", "t")
+    await token_manager.set_token("u1", "gmail", {"access_token": "t"})
     result = await gmail_adapter.perform_action("u1", params)
     assert result == {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
@@ -15,7 +15,7 @@ async def test_gmail_perform_action():
 @pytest.mark.asyncio
 async def test_gmail_perform_action_validation_error():
     await token_manager.init_redis(DummyRedis())
-    await token_manager.set_token("u1", "gmail", "t")
+    await token_manager.set_token("u1", "gmail", {"access_token": "t"})
     with pytest.raises(Exception):
         await gmail_adapter.perform_action("u1", {})
 
@@ -23,7 +23,7 @@ async def test_gmail_perform_action_validation_error():
 async def test_gmail_send_email():
     await token_manager.init_redis(DummyRedis())
     payload = {"to": "x@example.com"}
-    await token_manager.set_token("u1", "gmail", "t")
+    await token_manager.set_token("u1", "gmail", {"access_token": "t"})
     result = await gmail_adapter.send_email("u1", payload)
     assert result == {
         "status": "success",
@@ -36,7 +36,7 @@ async def test_gmail_send_email():
 @pytest.mark.asyncio
 async def test_gmail_send_email_validation_error():
     await token_manager.init_redis(DummyRedis())
-    await token_manager.set_token("u1", "gmail", "t")
+    await token_manager.set_token("u1", "gmail", {"access_token": "t"})
     with pytest.raises(Exception):
         await gmail_adapter.send_email("u1", {})
 
@@ -44,7 +44,7 @@ async def test_gmail_send_email_validation_error():
 async def test_google_calendar_create_event():
     await token_manager.init_redis(DummyRedis())
     payload = {"title": "meeting"}
-    await token_manager.set_token("u1", "google_calendar", "t")
+    await token_manager.set_token("u1", "google_calendar", {"access_token": "t"})
     result = await google_calendar_adapter.create_event("u1", payload)
     assert result == {
         "status": "success",
@@ -57,7 +57,7 @@ async def test_google_calendar_create_event():
 @pytest.mark.asyncio
 async def test_google_calendar_create_event_validation_error():
     await token_manager.init_redis(DummyRedis())
-    await token_manager.set_token("u1", "google_calendar", "t")
+    await token_manager.set_token("u1", "google_calendar", {"access_token": "t"})
     with pytest.raises(Exception):
         await google_calendar_adapter.create_event("u1", {})
 
@@ -65,7 +65,7 @@ async def test_google_calendar_create_event_validation_error():
 async def test_notion_create_task():
     await token_manager.init_redis(DummyRedis())
     payload = {"title": "task"}
-    await token_manager.set_token("u1", "notion", "t")
+    await token_manager.set_token("u1", "notion", {"access_token": "t"})
     result = await notion_adapter.create_task("u1", payload)
     assert result == {
         "status": "success",
@@ -78,7 +78,7 @@ async def test_notion_create_task():
 @pytest.mark.asyncio
 async def test_notion_create_task_validation_error():
     await token_manager.init_redis(DummyRedis())
-    await token_manager.set_token("u1", "notion", "t")
+    await token_manager.set_token("u1", "notion", {"access_token": "t"})
     with pytest.raises(Exception):
         await notion_adapter.create_task("u1", {})
 
@@ -86,7 +86,7 @@ async def test_notion_create_task_validation_error():
 async def test_zapier_perform_action():
     await token_manager.init_redis(DummyRedis())
     params = {"x": 2}
-    await token_manager.set_token("u1", "zapier", "t")
+    await token_manager.set_token("u1", "zapier", {"access_token": "t"})
     result = await zapier_adapter.perform_action("u1", params)
     assert result == {"message": "בוצעה פעולה דרך Zapier", "params": params}
 
@@ -94,6 +94,6 @@ async def test_zapier_perform_action():
 @pytest.mark.asyncio
 async def test_zapier_perform_action_validation_error():
     await token_manager.init_redis(DummyRedis())
-    await token_manager.set_token("u1", "zapier", "t")
+    await token_manager.set_token("u1", "zapier", {"access_token": "t"})
     with pytest.raises(Exception):
         await zapier_adapter.perform_action("u1", {})

--- a/action_engine/tests/test_auth.py
+++ b/action_engine/tests/test_auth.py
@@ -19,7 +19,7 @@ async def test_save_token_success():
     response = await main.save_token(payload, x_api_key=API_KEY)
     assert response.status_code == 200
     assert response.content == {"status": "ok"}
-    assert await token_manager.get_token("u1", "gmail") == "tok"
+    assert await token_manager.get_token("u1", "gmail") == {"access_token": "tok"}
 
 
 @pytest.mark.asyncio

--- a/action_engine/tests/test_router.py
+++ b/action_engine/tests/test_router.py
@@ -21,7 +21,7 @@ def make_payload(platform="gmail"):
 async def test_route_gmail_success():
     await token_manager.init_redis(DummyRedis())
     payload = make_payload("gmail")
-    await token_manager.set_token("u1", "gmail", "t")
+    await token_manager.set_token("u1", "gmail", {"access_token": "t"})
     response = await router.route_action({
         "platform": "gmail",
         "action_type": "perform_action",
@@ -41,7 +41,7 @@ async def test_route_gmail_success():
 async def test_route_google_calendar_success():
     await token_manager.init_redis(DummyRedis())
     payload = make_payload("google_calendar")
-    await token_manager.set_token("u1", "google_calendar", "t")
+    await token_manager.set_token("u1", "google_calendar", {"access_token": "t"})
     response = await router.route_action({
         "platform": "google_calendar",
         "action_type": "create_event",
@@ -63,7 +63,7 @@ async def test_route_google_calendar_success():
 async def test_route_notion_success():
     await token_manager.init_redis(DummyRedis())
     payload = make_payload("notion")
-    await token_manager.set_token("u1", "notion", "t")
+    await token_manager.set_token("u1", "notion", {"access_token": "t"})
     response = await router.route_action({
         "platform": "notion",
         "action_type": "create_task",
@@ -85,7 +85,7 @@ async def test_route_notion_success():
 async def test_route_zapier_success():
     await token_manager.init_redis(DummyRedis())
     payload = make_payload("zapier")
-    await token_manager.set_token("u1", "zapier", "t")
+    await token_manager.set_token("u1", "zapier", {"access_token": "t"})
     response = await router.route_action({
         "platform": "zapier",
         "action_type": "perform_action",
@@ -128,7 +128,7 @@ async def test_unknown_action_error():
 @pytest.mark.asyncio
 async def test_adapter_validation_error():
     await token_manager.init_redis(DummyRedis())
-    await token_manager.set_token("u1", "gmail", "t")
+    await token_manager.set_token("u1", "gmail", {"access_token": "t"})
     response = await router.route_action({
         "platform": "gmail",
         "action_type": "perform_action",

--- a/action_engine/tests/test_token_manager.py
+++ b/action_engine/tests/test_token_manager.py
@@ -6,20 +6,20 @@ from action_engine.tests.conftest import DummyRedis
 @pytest.mark.asyncio
 async def test_token_storage_per_user():
     await token_manager.init_redis(DummyRedis())
-    await token_manager.set_token("user1", "gmail", "tok1")
-    await token_manager.set_token("user2", "gmail", "tok2")
-    assert await token_manager.get_token("user1", "gmail") == "tok1"
-    assert await token_manager.get_token("user2", "gmail") == "tok2"
+    await token_manager.set_token("user1", "gmail", {"access_token": "tok1"})
+    await token_manager.set_token("user2", "gmail", {"access_token": "tok2"})
+    assert await token_manager.get_token("user1", "gmail") == {"access_token": "tok1"}
+    assert await token_manager.get_token("user2", "gmail") == {"access_token": "tok2"}
     assert await token_manager.get_token("user3", "gmail") is None
 
 
 @pytest.mark.asyncio
 async def test_token_isolation_between_platforms():
     await token_manager.init_redis(DummyRedis())
-    await token_manager.set_token("user1", "gmail", "tok1")
-    await token_manager.set_token("user1", "notion", "tok2")
-    assert await token_manager.get_token("user1", "gmail") == "tok1"
-    assert await token_manager.get_token("user1", "notion") == "tok2"
+    await token_manager.set_token("user1", "gmail", {"access_token": "tok1"})
+    await token_manager.set_token("user1", "notion", {"access_token": "tok2"})
+    assert await token_manager.get_token("user1", "gmail") == {"access_token": "tok1"}
+    assert await token_manager.get_token("user1", "notion") == {"access_token": "tok2"}
 
 
 @pytest.mark.asyncio
@@ -30,3 +30,16 @@ async def test_missing_redis_raises_error(monkeypatch):
     monkeypatch.setattr(token_manager, "redis", None)
     with pytest.raises(RuntimeError):
         await token_manager.get_token("u", "gmail")
+
+
+@pytest.mark.asyncio
+async def test_refresh_if_needed():
+    await token_manager.init_redis(DummyRedis())
+    expired = {
+        "access_token": "old",
+        "refresh_token": "ref",
+        "expires_at": 0,
+    }
+    await token_manager.set_token("u", "gmail", expired)
+    token = await token_manager.get_access_token("u", "gmail")
+    assert token.startswith("refreshed-")


### PR DESCRIPTION
## Summary
- support token dictionaries in token manager
- add expiration and refresh helpers
- update adapters to request refreshed tokens
- adjust token storage endpoint
- revise tests for new token handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688243c5ad78832e894c6ef1aff1f4d6