### PR TITLE
Implement BaseAdapter and HTTP error handling

### DIFF
--- a/action_engine/adapters/__init__.py
+++ b/action_engine/adapters/__init__.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.error
+import urllib.request
+
+from fastapi import HTTPException
+
+from action_engine.auth import token_manager
+from action_engine.logging.logger import get_logger, get_request_id
+
+
+class BaseAdapter:
+    """Base class for platform adapters providing HTTP utilities."""
+
+    platform: str = ""
+    base_url: str = ""
+
+    def __init__(self) -> None:
+        self.logger = get_logger(self.__class__.__name__)
+
+    async def _get_token(self, user_id: str) -> str:
+        token = await token_manager.get_token(user_id, self.platform)
+        if not token:
+            self.logger.info(
+                "Token missing",
+                extra={
+                    "user_id": user_id,
+                    "platform": self.platform,
+                    "request_id": get_request_id(),
+                },
+            )
+            raise HTTPException(status_code=401, detail=f"Missing token for {self.platform}")
+        return token
+
+    async def _request(
+        self, method: str, url: str, token: str, data: dict | None = None
+    ) -> dict:
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        body = None
+        if data is not None:
+            body = json.dumps(data).encode()
+        req = urllib.request.Request(url, data=body, headers=headers, method=method)
+        loop = asyncio.get_event_loop()
+        try:
+            resp = await loop.run_in_executor(None, urllib.request.urlopen, req)
+            resp_body = await loop.run_in_executor(None, resp.read)
+            status = resp.getcode()
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode()
+            self.logger.info(
+                "HTTP error",
+                extra={
+                    "status_code": exc.code,
+                    "detail": detail,
+                    "request_id": get_request_id(),
+                },
+            )
+            raise HTTPException(status_code=exc.code, detail=detail)
+        except Exception as exc:
+            self.logger.info(
+                "HTTP request failed",
+                extra={"detail": str(exc), "request_id": get_request_id()},
+            )
+            raise HTTPException(status_code=502, detail=str(exc))
+
+        if status >= 400:
+            detail = resp_body.decode()
+            self.logger.info(
+                "HTTP error",
+                extra={"status_code": status, "detail": detail, "request_id": get_request_id()},
+            )
+            raise HTTPException(status_code=status, detail=detail)
+
+        if resp_body:
+            try:
+                return json.loads(resp_body.decode())
+            except Exception:
+                return {"raw": resp_body.decode()}
+        return {}
+
+
+from . import gmail_adapter, google_calendar_adapter, notion_adapter, zapier_adapter
+
+__all__ = [
+    "BaseAdapter",
+    "gmail_adapter",
+    "google_calendar_adapter",
+    "notion_adapter",
+    "zapier_adapter",
+]

--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -1,7 +1,8 @@
 from action_engine.logging.logger import get_logger, get_request_id
-from action_engine.auth import token_manager
 from fastapi import HTTPException
 from pydantic import BaseModel
+
+from action_engine.adapters import BaseAdapter
 
 logger = get_logger(__name__)
 
@@ -25,49 +26,45 @@ def _validate(payload: dict, model: type[BaseModel]) -> BaseModel:
     return obj
 
 
-async def perform_action(user_id: str, params: dict):
-    """Mock action execution for Gmail."""
-    _validate(params, GmailPerformActionPayload)
-    token = await token_manager.get_token(user_id, "gmail")
-    if not token:
+class GmailAdapter(BaseAdapter):
+    platform = "gmail"
+    base_url = "https://gmail.googleapis.com"
+
+    async def perform_action(self, user_id: str, params: dict):
+        _validate(params, GmailPerformActionPayload)
+        token = await self._get_token(user_id)
+        await self._request("GET", f"{self.base_url}/gmail/v1/users/me/profile", token)
         logger.info(
-            "Gmail token missing",
-            extra={"user_id": user_id, "platform": "gmail", "request_id": get_request_id()},
+            "Gmail perform_action invoked",
+            extra={"params": params, "user_id": user_id, "request_id": get_request_id()},
         )
-        return {"status": "error", "message": "Missing token for gmail"}
+        return {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
-    logger.info(
-        "Gmail perform_action invoked",
-        extra={"params": params, "user_id": user_id, "request_id": get_request_id()},
-    )
-    return {"message": "בוצעה פעולה ב־Gmail", "params": params}
+    async def send_email(self, user_id: str, payload: dict) -> dict:
+        _validate(payload, GmailSendEmailPayload)
+        token = await self._get_token(user_id)
+        await self._request(
+            "POST",
+            f"{self.base_url}/gmail/v1/users/me/messages/send",
+            token,
+            data=payload,
+        )
+        logger.info(
+            "Gmail send_email",
+            extra={"payload": payload, "user_id": user_id, "request_id": get_request_id()},
+        )
+        return {
+            "status": "success",
+            "platform": "gmail",
+            "message": "Email sent successfully",
+            "data": payload,
+        }
 
+
+adapter = GmailAdapter()
+
+async def perform_action(user_id: str, params: dict):
+    return await adapter.perform_action(user_id, params)
 
 async def send_email(user_id: str, payload: dict) -> dict:
-    """Send an email via Gmail.
-
-    This function currently mocks the interaction with the Gmail API and
-    simply echoes back the provided payload.
-    """
-    _validate(payload, GmailSendEmailPayload)
-    # Basic logging for action invocation
-    token = await token_manager.get_token(user_id, "gmail")
-    if not token:
-        logger.info(
-            "Gmail token missing",
-            extra={"user_id": user_id, "platform": "gmail", "request_id": get_request_id()},
-        )
-        return {"status": "error", "message": "Missing token for gmail"}
-
-    logger.info(
-        "Gmail send_email",
-        extra={"payload": payload, "user_id": user_id, "request_id": get_request_id()},
-    )
-
-    return {
-        "status": "success",
-        "platform": "gmail",
-        "message": "Email sent successfully",
-        "data": payload,
-    }
-
+    return await adapter.send_email(user_id, payload)

--- a/action_engine/tests/test_adapters.py
+++ b/action_engine/tests/test_adapters.py
@@ -1,13 +1,29 @@
+import io
+import urllib.error
 import pytest
+import action_engine.adapters as adapters
 from action_engine.adapters import gmail_adapter, google_calendar_adapter, notion_adapter, zapier_adapter
 from action_engine.auth import token_manager
 from action_engine.tests.conftest import DummyRedis
 
+
+class DummyResponse:
+    def __init__(self, code: int = 200, data: bytes | None = None):
+        self._code = code
+        self._data = data or b"{}"
+
+    def getcode(self):
+        return self._code
+
+    def read(self):
+        return self._data
+
 @pytest.mark.asyncio
-async def test_gmail_perform_action():
+async def test_gmail_perform_action(monkeypatch):
     await token_manager.init_redis(DummyRedis())
     params = {"key": "value"}
     await token_manager.set_token("u1", "gmail", "t")
+    monkeypatch.setattr(adapters.urllib.request, "urlopen", lambda req: DummyResponse())
     result = await gmail_adapter.perform_action("u1", params)
     assert result == {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
@@ -20,10 +36,11 @@ async def test_gmail_perform_action_validation_error():
         await gmail_adapter.perform_action("u1", {})
 
 @pytest.mark.asyncio
-async def test_gmail_send_email():
+async def test_gmail_send_email(monkeypatch):
     await token_manager.init_redis(DummyRedis())
     payload = {"to": "x@example.com"}
     await token_manager.set_token("u1", "gmail", "t")
+    monkeypatch.setattr(adapters.urllib.request, "urlopen", lambda req: DummyResponse())
     result = await gmail_adapter.send_email("u1", payload)
     assert result == {
         "status": "success",
@@ -31,6 +48,20 @@ async def test_gmail_send_email():
         "message": "Email sent successfully",
         "data": payload,
     }
+
+
+@pytest.mark.asyncio
+async def test_gmail_http_error(monkeypatch):
+    await token_manager.init_redis(DummyRedis())
+    await token_manager.set_token("u1", "gmail", "t")
+
+    def raise_error(req):
+        raise urllib.error.HTTPError(req.full_url, 500, "", None, io.BytesIO(b"fail"))
+
+    monkeypatch.setattr(adapters.urllib.request, "urlopen", raise_error)
+
+    with pytest.raises(Exception):
+        await gmail_adapter.perform_action("u1", {"key": "v"})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add BaseAdapter with token and HTTP utilities
- use BaseAdapter in Gmail adapter to perform real HTTP requests
- mock HTTP calls in tests and cover HTTP error propagation via router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688243e9c720832e94a4a4634df6307e