### PR TITLE
Implement user token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Action Engine is a lightweight FastAPI service for routing automation requests t
    uvicorn action_engine.main:app --reload
    ```
 
+Use `/login` to obtain a bearer token for a given `user_id`. Include this token in the `Authorization` header when calling other endpoints.
+
 The API exposes a `/perform_action` endpoint that accepts a JSON payload with `platform`, `action_type` and `payload` fields.
 
 ## Supported platforms and actions
@@ -39,13 +41,13 @@ Additional adapter functions (e.g. `send_email` in the Gmail adapter) can be use
 
 ## Initiating OAuth
 
-Some adapters require OAuth tokens. Use the `/auth/start` and `/auth/callback` endpoints to complete the flow:
+Some adapters require OAuth tokens. Use the `/auth/start` and `/auth/callback` endpoints to complete the flow. Authenticate requests using a bearer token obtained from the `/login` endpoint:
 
 1. **Start authorization**
 
    ```bash
    curl -X POST http://localhost:8000/auth/start \
-        -H "X-API-Key: <your key>" \
+        -H "Authorization: Bearer <token>" \
         -d '{"user_id": "u1", "platform": "gmail", "client_id": "id", "client_secret": "secret", "redirect_uri": "https://app/callback"}'
    ```
 
@@ -57,7 +59,7 @@ Some adapters require OAuth tokens. Use the `/auth/start` and `/auth/callback` e
 
    ```bash
    curl -X POST http://localhost:8000/auth/callback \
-        -H "X-API-Key: <your key>" \
+        -H "Authorization: Bearer <token>" \
         -d '{"user_id": "u1", "platform": "gmail", "client_id": "id", "client_secret": "secret", "redirect_uri": "https://app/callback", "authorization_response": "..."}'
    ```
 

--- a/action_engine/auth/jwt_manager.py
+++ b/action_engine/auth/jwt_manager.py
@@ -1,0 +1,31 @@
+import time
+import json
+import base64
+import hmac
+import hashlib
+from typing import Optional
+from action_engine.config import SECRET_KEY, ACCESS_TOKEN_EXPIRE_SECONDS
+
+
+def create_token(user_id: str) -> str:
+    """Return a signed token for ``user_id``."""
+    payload = {"user_id": user_id, "exp": int(time.time()) + ACCESS_TOKEN_EXPIRE_SECONDS}
+    payload_bytes = json.dumps(payload, separators=(",", ":")).encode()
+    signature = hmac.new(SECRET_KEY.encode(), payload_bytes, hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(payload_bytes + b"." + signature).decode()
+
+
+def verify_token(token: str) -> Optional[str]:
+    """Return the ``user_id`` if the token is valid and not expired."""
+    try:
+        decoded = base64.urlsafe_b64decode(token.encode())
+        payload_bytes, signature = decoded.rsplit(b".", 1)
+        expected = hmac.new(SECRET_KEY.encode(), payload_bytes, hashlib.sha256).digest()
+        if not hmac.compare_digest(signature, expected):
+            return None
+        payload = json.loads(payload_bytes.decode())
+        if payload.get("exp", 0) < time.time():
+            return None
+        return payload.get("user_id")
+    except Exception:
+        return None

--- a/action_engine/config.py
+++ b/action_engine/config.py
@@ -10,5 +10,7 @@ if _env_path.exists():
                 key, value = line.strip().split('=', 1)
                 os.environ.setdefault(key, value)
 
-API_KEY = os.getenv('API_KEY', 'testkey')
+SECRET_KEY = os.getenv('SECRET_KEY', 'secret')
+ACCESS_TOKEN_EXPIRE_SECONDS = int(os.getenv('ACCESS_TOKEN_EXPIRE_SECONDS', '3600'))
+ENCRYPTION_KEY = os.getenv('ENCRYPTION_KEY', 'enc_key')
 REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379')

--- a/action_engine/logging/logger.py
+++ b/action_engine/logging/logger.py
@@ -34,6 +34,16 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(log_record)
 
 
+class SanitizeTokenFilter(logging.Filter):
+    """Remove token-like fields from log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple filter
+        for attr in ("token", "access_token", "refresh_token", "authorization"):
+            if hasattr(record, attr):
+                setattr(record, attr, "***")
+        return True
+
+
 def get_logger(name: str) -> logging.Logger:
     """Return a logger configured with :class:`JsonFormatter`."""
 
@@ -43,6 +53,7 @@ def get_logger(name: str) -> logging.Logger:
         handler = logging.StreamHandler()
         handler.setFormatter(JsonFormatter())
         logger.addHandler(handler)
+        logger.addFilter(SanitizeTokenFilter())
         logger.setLevel(logging.INFO)
         logger.propagate = False
     return logger

--- a/action_engine/tests/test_auth.py
+++ b/action_engine/tests/test_auth.py
@@ -9,14 +9,17 @@ from action_engine.tests.conftest import DummyRedis
 main = importlib.import_module("action_engine.main")
 
 
-API_KEY = "testkey"
+async def _token(user_id: str) -> str:
+    resp = await main.login({"user_id": user_id})
+    return resp.content["token"]
 
 
 @pytest.mark.asyncio
 async def test_save_token_success():
     await token_manager.init_redis(DummyRedis())
     payload = {"user_id": "u1", "platform": "gmail", "access_token": "tok"}
-    response = await main.save_token(payload, x_api_key=API_KEY)
+    token = await _token("u1")
+    response = await main.save_token(payload, authorization=f"Bearer {token}")
     assert response.status_code == 200
     assert response.content == {"status": "ok"}
     assert await token_manager.get_token("u1", "gmail") == {"access_token": "tok"}
@@ -26,7 +29,8 @@ async def test_save_token_success():
 async def test_save_token_validation_error():
     await token_manager.init_redis(DummyRedis())
     payload = {"user_id": "u1", "platform": "gmail"}  # missing access_token
-    response = await main.save_token(payload, x_api_key=API_KEY)
+    token = await _token("u1")
+    response = await main.save_token(payload, authorization=f"Bearer {token}")
     assert response.status_code == 400
     assert "Invalid token payload" in response.content["error"]
 
@@ -35,12 +39,12 @@ async def test_save_token_validation_error():
 async def test_save_token_unauthorized():
     await token_manager.init_redis(DummyRedis())
     payload = {"user_id": "u1", "platform": "gmail", "access_token": "tok"}
-    response = await main.save_token(payload, x_api_key="bad")
+    response = await main.save_token(payload, authorization="Bearer bad")
     assert response.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_perform_action_requires_api_key():
+async def test_perform_action_requires_token():
     await token_manager.init_redis(DummyRedis())
     request = main.ActionRequest(
         action_type="perform_action",
@@ -48,12 +52,12 @@ async def test_perform_action_requires_api_key():
         user_id="u1",
         payload={}
     )
-    response = await main.perform_action(request, x_api_key="bad")
+    response = await main.perform_action(request, authorization="Bearer bad")
     assert response.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_perform_action_success_with_key():
+async def test_perform_action_success_with_token():
     await token_manager.init_redis(DummyRedis())
     request = main.ActionRequest(
         action_type="perform_action",
@@ -61,5 +65,6 @@ async def test_perform_action_success_with_key():
         user_id="u1",
         payload={}
     )
-    response = await main.perform_action(request, x_api_key=API_KEY)
+    token = await _token("u1")
+    response = await main.perform_action(request, authorization=f"Bearer {token}")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add token issuance and verification helpers
- secure token storage in Redis with simple encryption
- add token sanitization filter to logger
- switch API to bearer tokens instead of a single API key
- update tests and docs for token authentication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688243e97704832eb5ebabd09ee30cf9