### PR TITLE
Implement OAuth client config and base adapter

### DIFF
--- a/action_engine/adapters/__init__.py
+++ b/action_engine/adapters/__init__.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Optional
+from urllib import request, error
+
+from fastapi import HTTPException
+
+from action_engine.logging.logger import get_logger, get_request_id
+from action_engine.auth import token_manager
+
+
+class BaseAdapter:
+    """Base adapter providing token handling and HTTP helpers."""
+
+    def __init__(self, platform: str) -> None:
+        self.platform = platform
+        self.logger = get_logger(__name__)
+
+    async def _get_token(self, user_id: str) -> str:
+        token = await token_manager.get_access_token(user_id, self.platform)
+        if not token:
+            self.logger.info(
+                f"{self.platform} token missing",
+                extra={"user_id": user_id, "platform": self.platform, "request_id": get_request_id()},
+            )
+            raise HTTPException(status_code=400, detail=f"Missing token for {self.platform}")
+        return token
+
+    async def send_http_request(
+        self,
+        method: str,
+        url: str,
+        headers: Optional[dict[str, str]] = None,
+        data: Optional[Any] = None,
+    ) -> Any:
+        """Send an HTTP request asynchronously using urllib."""
+
+        async def _do_request() -> Any:
+            _headers = dict(headers or {})
+            body = None
+            if data is not None:
+                if isinstance(data, (dict, list)):
+                    body = json.dumps(data).encode()
+                    _headers.setdefault("Content-Type", "application/json")
+                elif isinstance(data, str):
+                    body = data.encode()
+                else:
+                    body = data
+            req = request.Request(url, data=body, headers=_headers, method=method)
+            try:
+                with request.urlopen(req) as resp:
+                    resp_body = resp.read()
+                    try:
+                        return json.loads(resp_body)
+                    except Exception:  # pragma: no cover - non JSON response
+                        return resp_body.decode()
+            except error.HTTPError as exc:
+                raise HTTPException(status_code=exc.code, detail=exc.reason)
+            except Exception as exc:  # pragma: no cover - network failure
+                raise HTTPException(status_code=500, detail=str(exc))
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, _do_request)
+
+    async def post(
+        self, url: str, headers: Optional[dict[str, str]] = None, data: Optional[Any] = None
+    ) -> Any:
+        return await self.send_http_request("POST", url, headers=headers, data=data)
+
+__all__ = ["BaseAdapter"]

--- a/action_engine/adapters/gmail_adapter.py
+++ b/action_engine/adapters/gmail_adapter.py
@@ -1,7 +1,8 @@
-from action_engine.logging.logger import get_logger, get_request_id
-from action_engine.auth import token_manager
 from fastapi import HTTPException
 from pydantic import BaseModel
+
+from action_engine.logging.logger import get_logger, get_request_id
+from action_engine.adapters import BaseAdapter
 
 logger = get_logger(__name__)
 
@@ -25,49 +26,47 @@ def _validate(payload: dict, model: type[BaseModel]) -> BaseModel:
     return obj
 
 
-async def perform_action(user_id: str, params: dict):
-    """Mock action execution for Gmail."""
-    _validate(params, GmailPerformActionPayload)
-    token = await token_manager.get_access_token(user_id, "gmail")
-    if not token:
+class GmailAdapter(BaseAdapter):
+    """Adapter for Gmail actions using the Gmail API."""
+
+    SEND_API_URL = "https://gmail.googleapis.com/gmail/v1/users/me/messages/send"
+
+    def __init__(self) -> None:
+        super().__init__("gmail")
+
+    async def perform_action(self, user_id: str, params: dict):
+        _validate(params, GmailPerformActionPayload)
+        await self._get_token(user_id)
         logger.info(
-            "Gmail token missing",
-            extra={"user_id": user_id, "platform": "gmail", "request_id": get_request_id()},
+            "Gmail perform_action invoked",
+            extra={"params": params, "user_id": user_id, "request_id": get_request_id()},
         )
-        return {"status": "error", "message": "Missing token for gmail"}
+        return {"message": "בוצעה פעולה ב־Gmail", "params": params}
 
-    logger.info(
-        "Gmail perform_action invoked",
-        extra={"params": params, "user_id": user_id, "request_id": get_request_id()},
-    )
-    return {"message": "בוצעה פעולה ב־Gmail", "params": params}
+    async def send_email(self, user_id: str, payload: dict) -> dict:
+        _validate(payload, GmailSendEmailPayload)
+        token = await self._get_token(user_id)
+        logger.info(
+            "Gmail send_email",
+            extra={"payload": payload, "user_id": user_id, "request_id": get_request_id()},
+        )
+        await self.post(
+            self.SEND_API_URL,
+            headers={"Authorization": f"Bearer {token}"},
+            data=payload,
+        )
+        return {
+            "status": "success",
+            "platform": "gmail",
+            "message": "Email sent successfully",
+            "data": payload,
+        }
 
+
+adapter = GmailAdapter()
+
+async def perform_action(user_id: str, params: dict):
+    return await adapter.perform_action(user_id, params)
 
 async def send_email(user_id: str, payload: dict) -> dict:
-    """Send an email via Gmail.
-
-    This function currently mocks the interaction with the Gmail API and
-    simply echoes back the provided payload.
-    """
-    _validate(payload, GmailSendEmailPayload)
-    # Basic logging for action invocation
-    token = await token_manager.get_access_token(user_id, "gmail")
-    if not token:
-        logger.info(
-            "Gmail token missing",
-            extra={"user_id": user_id, "platform": "gmail", "request_id": get_request_id()},
-        )
-        return {"status": "error", "message": "Missing token for gmail"}
-
-    logger.info(
-        "Gmail send_email",
-        extra={"payload": payload, "user_id": user_id, "request_id": get_request_id()},
-    )
-
-    return {
-        "status": "success",
-        "platform": "gmail",
-        "message": "Email sent successfully",
-        "data": payload,
-    }
-
+    return await adapter.send_email(user_id, payload)

--- a/action_engine/config.py
+++ b/action_engine/config.py
@@ -14,3 +14,14 @@ SECRET_KEY = os.getenv('SECRET_KEY', 'secret')
 ACCESS_TOKEN_EXPIRE_SECONDS = int(os.getenv('ACCESS_TOKEN_EXPIRE_SECONDS', '3600'))
 ENCRYPTION_KEY = os.getenv('ENCRYPTION_KEY', 'enc_key')
 REDIS_URL = os.getenv('REDIS_URL', 'redis://localhost:6379')
+
+
+def get_oauth_config(platform: str) -> dict:
+    """Return OAuth configuration values for a given platform."""
+    prefix = platform.upper()
+    return {
+        'client_id': os.getenv(f'{prefix}_CLIENT_ID', ''),
+        'client_secret': os.getenv(f'{prefix}_CLIENT_SECRET', ''),
+        'redirect_uri': os.getenv(f'{prefix}_REDIRECT_URI', ''),
+        'scope': os.getenv(f'{prefix}_SCOPE', ''),
+    }

--- a/action_engine/tests/test_oauth.py
+++ b/action_engine/tests/test_oauth.py
@@ -1,31 +1,32 @@
 import importlib
-import json
+import os
 import pytest
+
 from action_engine.auth import token_manager
 from action_engine.tests.conftest import DummyRedis
 
 # Import main after FastAPI stubs are set up in conftest
 main = importlib.import_module("action_engine.main")
 
+
 async def _token(user_id: str) -> str:
     resp = await main.login({"user_id": user_id})
     return resp.content["token"]
 
+
 @pytest.mark.asyncio
-async def test_start_oauth_returns_url():
+async def test_start_oauth_returns_url(monkeypatch):
     await token_manager.init_redis(DummyRedis())
-    data = {
-        "user_id": "u1",
-        "platform": "gmail",
-        "client_id": "id",
-        "client_secret": "secret",
-        "redirect_uri": "https://app/cb",
-        "scope": "email",
-    }
+    monkeypatch.setitem(os.environ, "GMAIL_CLIENT_ID", "id")
+    monkeypatch.setitem(os.environ, "GMAIL_CLIENT_SECRET", "secret")
+    monkeypatch.setitem(os.environ, "GMAIL_REDIRECT_URI", "https://app/cb")
+    importlib.reload(main.config)
+    importlib.reload(main)
     token = await _token("u1")
-    response = await main.start_oauth(data, authorization=f"Bearer {token}")
+    response = await main.start_oauth({"user_id": "u1", "platform": "gmail"}, authorization=f"Bearer {token}")
     assert response.status_code == 200
     assert response.content["authorization_url"].startswith("https://auth.example.com")
+
 
 @pytest.mark.asyncio
 async def test_oauth_callback_stores_token():
@@ -43,3 +44,15 @@ async def test_oauth_callback_stores_token():
     assert response.status_code == 200
     stored = await token_manager.get_token("u1", "gmail")
     assert stored["access_token"] == "dummy-access-token"
+
+
+def test_build_oauth_client_from_config(monkeypatch):
+    monkeypatch.setitem(os.environ, "GMAIL_CLIENT_ID", "cid")
+    monkeypatch.setitem(os.environ, "GMAIL_CLIENT_SECRET", "csecret")
+    monkeypatch.setitem(os.environ, "GMAIL_REDIRECT_URI", "https://cb")
+    importlib.reload(main.config)
+    importlib.reload(main)
+    client = main.build_oauth_client("gmail")
+    assert client.client_id == "cid"
+    assert client.client_secret == "csecret"
+    assert client.redirect_uri == "https://cb"


### PR DESCRIPTION
## Summary
- create `BaseAdapter` for HTTP requests and token retrieval
- refactor Gmail adapter to subclass `BaseAdapter`
- support OAuth config via environment variables
- add helper `build_oauth_client` and update `/auth/start`
- extend unit tests for Gmail adapter and OAuth features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68824820cc3c832e9f6ebdf65fa3497c