### PR TITLE
Add Engine Control Core service

### DIFF
--- a/action_engine/tests/conftest.py
+++ b/action_engine/tests/conftest.py
@@ -39,6 +39,11 @@ class DummyFastAPI:
             return func
         return decorator
 
+    def get(self, path):
+        def decorator(func):
+            return func
+        return decorator
+
     def add_middleware(self, middleware_class, **options):
         self.middlewares.append((middleware_class, options))
 

--- a/engine_control/auth_middleware.py
+++ b/engine_control/auth_middleware.py
@@ -1,0 +1,18 @@
+import os
+from fastapi import HTTPException
+
+AUTHORIZED_ENGINES = {
+    "action": os.getenv("ACTION_ENGINE_KEY", "action-key"),
+    "vault": os.getenv("VAULT_ENGINE_KEY", "vault-key"),
+    "sync": os.getenv("SYNC_ENGINE_KEY", "sync-key"),
+    "local": os.getenv("LOCAL_ENGINE_KEY", "local-key"),
+}
+
+
+def verify_engine(engine_id: str | None, engine_key: str | None) -> None:
+    """Ensure the caller is an authorized engine."""
+    if not engine_id or not engine_key:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    key = AUTHORIZED_ENGINES.get(engine_id)
+    if key != engine_key:
+        raise HTTPException(status_code=403, detail="Forbidden")

--- a/engine_control/engine_config.py
+++ b/engine_control/engine_config.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+_ENGINE_CONFIGS: Dict[str, Dict] = {}
+
+
+def set_engine_config(engine_id: str, config: Dict) -> None:
+    """Store configuration for an engine."""
+    _ENGINE_CONFIGS[engine_id] = config
+
+
+def get_engine_config(engine_id: str) -> Dict:
+    """Return configuration for an engine or empty dict."""
+    return _ENGINE_CONFIGS.get(engine_id, {})
+
+
+def clear_engine_configs() -> None:
+    """Remove all configs (mainly for tests)."""
+    _ENGINE_CONFIGS.clear()

--- a/engine_control/engine_logger.py
+++ b/engine_control/engine_logger.py
@@ -1,0 +1,76 @@
+import json
+import logging
+from typing import Any
+from datetime import datetime
+import contextvars
+import uuid
+
+# Context variable storing the current request ID
+request_id_ctx_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "request_id",
+    default=None,
+)
+
+
+def get_request_id() -> str | None:
+    """Return the request ID for the current context if available."""
+    return request_id_ctx_var.get()
+
+
+class JsonFormatter(logging.Formatter):
+    """Formatter that outputs logs as JSON strings."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - simple formatting
+        log_record = {
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+            "time": datetime.utcnow().isoformat(),
+        }
+        if record.exc_info:
+            log_record["exception"] = self.formatException(record.exc_info)
+        if hasattr(record, "request_id") and record.request_id is not None:
+            log_record["request_id"] = record.request_id
+        return json.dumps(log_record)
+
+
+class SanitizeTokenFilter(logging.Filter):
+    """Remove token-like fields from log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple filter
+        for attr in ("token", "access_token", "refresh_token", "authorization"):
+            if hasattr(record, attr):
+                setattr(record, attr, "***")
+        return True
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger configured with :class:`JsonFormatter`."""
+
+    logger = logging.getLogger(name)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(JsonFormatter())
+        logger.addHandler(handler)
+        logger.addFilter(SanitizeTokenFilter())
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+    return logger
+
+
+class RequestIdMiddleware:
+    """Simple ASGI middleware that assigns a UUID request ID for each request."""
+
+    def __init__(self, app: Any):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):  # pragma: no cover - simple middleware
+        if scope.get("type") == "http":
+            token = request_id_ctx_var.set(str(uuid.uuid4()))
+            try:
+                await self.app(scope, receive, send)
+            finally:
+                request_id_ctx_var.reset(token)
+        else:
+            await self.app(scope, receive, send)

--- a/engine_control/engine_registry.py
+++ b/engine_control/engine_registry.py
@@ -1,0 +1,21 @@
+from typing import Dict, List, Optional
+
+_engine_store: Dict[str, Dict] = {}
+
+
+def register_engine(engine_id: str, permissions: Dict, depends_on: Optional[List[str]] = None) -> None:
+    """Register an engine with its permissions and dependencies."""
+    _engine_store[engine_id] = {
+        "permissions": permissions or {},
+        "depends_on": depends_on or [],
+    }
+
+
+def get_engine(engine_id: str) -> Optional[Dict]:
+    """Return engine information if registered."""
+    return _engine_store.get(engine_id)
+
+
+def clear_engines() -> None:
+    """Remove all registered engines (mainly for tests)."""
+    _engine_store.clear()

--- a/engine_control/main.py
+++ b/engine_control/main.py
@@ -1,0 +1,102 @@
+from fastapi import FastAPI, Header, HTTPException
+from fastapi.responses import JSONResponse
+
+from .auth_middleware import verify_engine
+from .engine_registry import register_engine
+from .platform_registry import set_platform_status
+from .permission_checker import is_action_allowed as check_action
+from .engine_config import get_engine_config as fetch_config, set_engine_config
+from .engine_logger import get_logger, RequestIdMiddleware, get_request_id
+
+app = FastAPI()
+app.add_middleware(RequestIdMiddleware)
+logger = get_logger(__name__)
+
+
+@app.post("/register_engine")
+async def register_engine_endpoint(
+    data: dict,
+    x_engine_id: str = Header(None),
+    x_engine_key: str = Header(None),
+):
+    verify_engine(x_engine_id, x_engine_key)
+    engine_id = data.get("engine_id")
+    permissions = data.get("permissions", {})
+    depends_on = data.get("depends_on", [])
+    if not isinstance(engine_id, str) or not engine_id:
+        raise HTTPException(status_code=400, detail="Invalid engine_id")
+    register_engine(engine_id, permissions, depends_on)
+    logger.info(
+        "Engine registered",
+        extra={"engine_id": engine_id, "request_id": get_request_id()},
+    )
+    return JSONResponse({"status": "ok"})
+
+
+@app.post("/set_platform_status")
+async def set_platform_status_endpoint(
+    data: dict,
+    x_engine_id: str = Header(None),
+    x_engine_key: str = Header(None),
+):
+    verify_engine(x_engine_id, x_engine_key)
+    platform = data.get("platform")
+    status = data.get("status")
+    if not isinstance(platform, str) or status not in {"active", "maintenance", "deprecated"}:
+        raise HTTPException(status_code=400, detail="Invalid platform status")
+    set_platform_status(platform, status)
+    logger.info(
+        "Platform status updated",
+        extra={"platform": platform, "status": status, "request_id": get_request_id()},
+    )
+    return JSONResponse({"status": "ok"})
+
+
+@app.post("/set_engine_config")
+async def set_engine_config_endpoint(
+    data: dict,
+    x_engine_id: str = Header(None),
+    x_engine_key: str = Header(None),
+):
+    verify_engine(x_engine_id, x_engine_key)
+    engine_id = data.get("engine_id")
+    config = data.get("config", {})
+    if not isinstance(engine_id, str) or not engine_id:
+        raise HTTPException(status_code=400, detail="Invalid engine_id")
+    set_engine_config(engine_id, config)
+    return JSONResponse({"status": "ok"})
+
+
+@app.get("/engine_config/{engine_id}")
+async def engine_config_endpoint(
+    engine_id: str,
+    x_engine_id: str = Header(None),
+    x_engine_key: str = Header(None),
+):
+    verify_engine(x_engine_id, x_engine_key)
+    config = fetch_config(engine_id)
+    return JSONResponse(config)
+
+
+@app.post("/is_action_allowed")
+async def is_action_allowed_endpoint(
+    data: dict,
+    x_engine_id: str = Header(None),
+    x_engine_key: str = Header(None),
+):
+    verify_engine(x_engine_id, x_engine_key)
+    engine_id = data.get("engine_id")
+    platform = data.get("platform")
+    action_type = data.get("action_type")
+    if not all(isinstance(v, str) and v for v in (engine_id, platform, action_type)):
+        raise HTTPException(status_code=400, detail="Invalid request")
+    result = check_action(engine_id, platform, action_type)
+    logger.info(
+        "Authorization checked",
+        extra={
+            "engine_id": engine_id,
+            "platform": platform,
+            "request_id": get_request_id(),
+        },
+    )
+    return JSONResponse(result)

--- a/engine_control/permission_checker.py
+++ b/engine_control/permission_checker.py
@@ -1,0 +1,23 @@
+from typing import Dict, List
+from .engine_registry import get_engine
+from .platform_registry import get_platform_status
+
+
+def is_action_allowed(engine_id: str, platform: str, action_type: str) -> Dict:
+    """Return whether the action is permitted for the engine and platform."""
+    engine = get_engine(engine_id)
+    status = get_platform_status(platform)
+    if not engine:
+        return {"action_allowed": False, "required_scopes": [], "platform_status": status}
+    if status != "active":
+        return {"action_allowed": False, "required_scopes": [], "platform_status": status}
+    permissions = engine.get("permissions", {})
+    scopes: List[str] | None = None
+    if platform in permissions:
+        scopes = permissions[platform].get(action_type)
+    allowed = scopes is not None
+    return {
+        "action_allowed": allowed,
+        "required_scopes": scopes or [],
+        "platform_status": status,
+    }

--- a/engine_control/platform_registry.py
+++ b/engine_control/platform_registry.py
@@ -1,0 +1,23 @@
+from typing import Dict
+
+_PLATFORM_STATUS: Dict[str, str] = {}
+
+
+VALID_STATUSES = {"active", "maintenance", "deprecated"}
+
+
+def set_platform_status(platform_name: str, status: str) -> None:
+    """Set operational status for a platform."""
+    if status not in VALID_STATUSES:
+        raise ValueError("Invalid status")
+    _PLATFORM_STATUS[platform_name] = status
+
+
+def get_platform_status(platform_name: str) -> str:
+    """Return status for platform, defaulting to 'active'."""
+    return _PLATFORM_STATUS.get(platform_name, "active")
+
+
+def clear_platforms() -> None:
+    """Remove all platform statuses (mainly for tests)."""
+    _PLATFORM_STATUS.clear()

--- a/engine_control/tests/conftest.py
+++ b/engine_control/tests/conftest.py
@@ -1,0 +1,3 @@
+from action_engine.tests.conftest import DummyRedis, pytest_pyfunc_call, pytest_configure
+
+__all__ = ["DummyRedis"]

--- a/engine_control/tests/test_authorization.py
+++ b/engine_control/tests/test_authorization.py
@@ -1,0 +1,84 @@
+import importlib
+import pytest
+from fastapi import HTTPException
+
+# Import main after FastAPI stubs are loaded via conftest
+main = importlib.import_module("engine_control.main")
+
+from engine_control import engine_registry, platform_registry, engine_config
+
+
+@pytest.mark.asyncio
+async def test_register_engine_and_allowed_action():
+    engine_registry.clear_engines()
+    platform_registry.clear_platforms()
+    engine_config.clear_engine_configs()
+
+    data = {
+        "engine_id": "action",
+        "permissions": {
+            "gmail": {"send_mail": ["mail.send"]}
+        },
+    }
+    resp = await main.register_engine_endpoint(data, x_engine_id="local", x_engine_key="local-key")
+    assert resp.status_code == 200
+
+    await main.set_platform_status_endpoint({"platform": "gmail", "status": "active"}, x_engine_id="local", x_engine_key="local-key")
+
+    result = await main.is_action_allowed_endpoint(
+        {"engine_id": "action", "platform": "gmail", "action_type": "send_mail"},
+        x_engine_id="local",
+        x_engine_key="local-key",
+    )
+    assert result.status_code == 200
+    assert result.content == {
+        "action_allowed": True,
+        "required_scopes": ["mail.send"],
+        "platform_status": "active",
+    }
+
+
+@pytest.mark.asyncio
+async def test_action_denied_for_unregistered_engine():
+    engine_registry.clear_engines()
+    platform_registry.clear_platforms()
+    result = await main.is_action_allowed_endpoint(
+        {"engine_id": "missing", "platform": "gmail", "action_type": "send"},
+        x_engine_id="local",
+        x_engine_key="local-key",
+    )
+    assert result.status_code == 200
+    assert result.content["action_allowed"] is False
+
+
+@pytest.mark.asyncio
+async def test_platform_maintenance_rejects_action():
+    engine_registry.clear_engines()
+    platform_registry.clear_platforms()
+    await main.register_engine_endpoint({"engine_id": "a", "permissions": {"gmail": {"send": []}}}, x_engine_id="local", x_engine_key="local-key")
+    await main.set_platform_status_endpoint({"platform": "gmail", "status": "maintenance"}, x_engine_id="local", x_engine_key="local-key")
+    result = await main.is_action_allowed_endpoint(
+        {"engine_id": "a", "platform": "gmail", "action_type": "send"},
+        x_engine_id="local",
+        x_engine_key="local-key",
+    )
+    assert result.content["action_allowed"] is False
+    assert result.content["platform_status"] == "maintenance"
+
+
+@pytest.mark.asyncio
+async def test_missing_headers_return_403():
+    with pytest.raises(HTTPException) as exc:
+        await main.is_action_allowed_endpoint({"engine_id": "a", "platform": "gmail", "action_type": "send"}, x_engine_id=None, x_engine_key=None)
+    assert exc.value.status_code == 403
+
+@pytest.mark.asyncio
+async def test_invalid_headers_return_403():
+    with pytest.raises(HTTPException) as exc:
+        await main.is_action_allowed_endpoint(
+            {"engine_id": "a", "platform": "gmail", "action_type": "send"},
+            x_engine_id="bad",
+            x_engine_key="bad",
+        )
+    assert exc.value.status_code == 403
+


### PR DESCRIPTION
## Summary
- implement Engine Control service with endpoints for registering engines,
  setting platform status, storing configs, and checking permissions
- add auth middleware and logging utilities
- create engine registry, platform registry, permission checker and config store
- expand FastAPI test stub to support GET
- add tests covering authorization cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688296c9b684832ebc7bc2e7b71980aa