### PR TITLE
Add .env.example files for engines

### DIFF
--- a/action_engine/.env.example
+++ b/action_engine/.env.example
@@ -1,0 +1,33 @@
+# Example configuration for the Action Engine
+
+# Port the HTTP server listens on
+PORT=8000
+
+# Identifier for this engine when communicating with others
+ENGINE_ID=action
+
+# Shared token used for authenticating with Engine Control and Vault
+ENGINE_TOKEN=your_action_engine_key
+
+# Base URL of the Vault Engine
+VAULT_URL=http://localhost:9000
+# Token expected by the Vault Engine
+VAULT_ENGINE_KEY=your_vault_engine_key
+
+# Redis instance used to store tokens or temporary data
+REDIS_URL=redis://localhost:6379
+
+# Secret used to sign JWTs issued by the Action Engine
+SECRET_KEY=your_secret_key
+
+# JWT access token lifetime in seconds
+ACCESS_TOKEN_EXPIRE_SECONDS=3600
+
+# Optional symmetric key for encrypting sensitive payloads
+ENCRYPTION_KEY=your_encryption_key
+
+# OAuth client settings for Gmail (example)
+GMAIL_CLIENT_ID=your_gmail_client_id
+GMAIL_CLIENT_SECRET=your_gmail_client_secret
+GMAIL_REDIRECT_URI=http://localhost:8000/auth/callback/gmail
+GMAIL_SCOPE=https://www.googleapis.com/auth/gmail.send

--- a/engine_control/.env.example
+++ b/engine_control/.env.example
@@ -1,0 +1,10 @@
+# Example configuration for the Engine Control service
+
+# Port the HTTP server listens on
+PORT=8000
+
+# Shared authentication keys that other engines must present
+ACTION_ENGINE_KEY=your_action_engine_key
+VAULT_ENGINE_KEY=your_vault_engine_key
+SYNC_ENGINE_KEY=your_sync_engine_key
+LOCAL_ENGINE_KEY=your_local_engine_key

--- a/goal_engine/.env.example
+++ b/goal_engine/.env.example
@@ -1,0 +1,17 @@
+# Example configuration for the upcoming Goal Engine
+
+# Port the service listens on
+PORT=8000
+
+# Identifier for this engine
+ENGINE_ID=goal
+
+# Shared token presented to Engine Control and Vault
+ENGINE_TOKEN=your_goal_engine_key
+
+# Location of dependent services
+ENGINE_CONTROL_URL=http://localhost:8001
+VAULT_URL=http://localhost:9000
+
+# Redis instance used for temporary storage
+REDIS_URL=redis://localhost:6379

--- a/strategy_engine/.env.example
+++ b/strategy_engine/.env.example
@@ -1,0 +1,17 @@
+# Example configuration for the upcoming Strategy Engine
+
+# Port the service listens on
+PORT=8000
+
+# Identifier for this engine
+ENGINE_ID=strategy
+
+# Shared token presented to Engine Control and Vault
+ENGINE_TOKEN=your_strategy_engine_key
+
+# Location of dependent services
+ENGINE_CONTROL_URL=http://localhost:8001
+VAULT_URL=http://localhost:9000
+
+# Redis instance used for temporary storage
+REDIS_URL=redis://localhost:6379

--- a/sync_engine/.env.example
+++ b/sync_engine/.env.example
@@ -1,0 +1,17 @@
+# Example configuration for the upcoming Sync Engine
+
+# Port the service listens on
+PORT=8000
+
+# Identifier for this engine
+ENGINE_ID=sync
+
+# Shared token presented to Engine Control and Vault
+ENGINE_TOKEN=your_sync_engine_key
+
+# Location of dependent services
+ENGINE_CONTROL_URL=http://localhost:8001
+VAULT_URL=http://localhost:9000
+
+# Redis instance used for temporary storage
+REDIS_URL=redis://localhost:6379

--- a/vault_engine/.env.example
+++ b/vault_engine/.env.example
@@ -1,0 +1,25 @@
+# Example configuration for the Vault Engine
+
+# Port the service listens on
+PORT=9000
+
+# Identifier for this engine
+ENGINE_ID=vault
+
+# Tokens accepted from calling engines
+ACTION_ENGINE_KEY=your_action_engine_key
+SYNC_ENGINE_KEY=your_sync_engine_key
+LOCAL_ENGINE_KEY=your_local_engine_key
+
+# Redis connection used for encrypted token storage
+VAULT_REDIS_URL=redis://localhost:6380
+
+# AES-256-CBC encryption settings
+VAULT_ENCRYPTION_KEY=32_byte_base64_key_here
+VAULT_ENCRYPTION_IV=16_byte_base64_iv_here
+
+# OAuth client settings for Gmail (example)
+GMAIL_CLIENT_ID=your_gmail_client_id
+GMAIL_CLIENT_SECRET=your_gmail_client_secret
+GMAIL_REDIRECT_URI=http://localhost:8000/auth/callback/gmail
+GMAIL_SCOPE=https://www.googleapis.com/auth/gmail.send


### PR DESCRIPTION
## Summary
- create environment variable examples for `action_engine`, `engine_control`, `vault_engine`
- scaffold `.env.example` files for upcoming `sync_engine`, `goal_engine` and `strategy_engine`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829a104f64832e85b12171577cb3a2