### PR TITLE
Refine environment examples

### DIFF
--- a/action_engine/.env.example
+++ b/action_engine/.env.example
@@ -14,16 +14,16 @@ VAULT_URL=http://localhost:9000
 # Token expected by the Vault Engine
 VAULT_ENGINE_KEY=your_vault_engine_key
 
-# Redis instance used to store tokens or temporary data
+# Redis instance used to cache tokens or rate limit requests
 REDIS_URL=redis://localhost:6379
 
-# Secret used to sign JWTs issued by the Action Engine
+# Secret used to sign JWTs for the ``/login`` endpoint
 SECRET_KEY=your_secret_key
 
 # JWT access token lifetime in seconds
 ACCESS_TOKEN_EXPIRE_SECONDS=3600
 
-# Optional symmetric key for encrypting sensitive payloads
+# Optional symmetric key for encrypting payloads before storage
 ENCRYPTION_KEY=your_encryption_key
 
 # OAuth client settings for Gmail (example)

--- a/engine_control/.env.example
+++ b/engine_control/.env.example
@@ -1,4 +1,5 @@
 # Example configuration for the Engine Control service
+# Only engine authentication keys should be defined here
 
 # Port the HTTP server listens on
 PORT=8000

--- a/goal_engine/.env.example
+++ b/goal_engine/.env.example
@@ -13,5 +13,8 @@ ENGINE_TOKEN=your_goal_engine_key
 ENGINE_CONTROL_URL=http://localhost:8001
 VAULT_URL=http://localhost:9000
 
+# API key used for generating goals via GPT
+OPENAI_API_KEY=your_openai_api_key
+
 # Redis instance used for temporary storage
 REDIS_URL=redis://localhost:6379

--- a/strategy_engine/.env.example
+++ b/strategy_engine/.env.example
@@ -13,5 +13,8 @@ ENGINE_TOKEN=your_strategy_engine_key
 ENGINE_CONTROL_URL=http://localhost:8001
 VAULT_URL=http://localhost:9000
 
+# API key used for GPT-based strategy generation
+OPENAI_API_KEY=your_openai_api_key
+
 # Redis instance used for temporary storage
 REDIS_URL=redis://localhost:6379

--- a/sync_engine/.env.example
+++ b/sync_engine/.env.example
@@ -13,5 +13,11 @@ ENGINE_TOKEN=your_sync_engine_key
 ENGINE_CONTROL_URL=http://localhost:8001
 VAULT_URL=http://localhost:9000
 
+# OAuth client settings for syncing calendar data
+CALENDAR_CLIENT_ID=your_calendar_client_id
+CALENDAR_CLIENT_SECRET=your_calendar_client_secret
+CALENDAR_REDIRECT_URI=http://localhost:8000/auth/callback/calendar
+CALENDAR_SCOPE=https://www.googleapis.com/auth/calendar.events
+
 # Redis instance used for temporary storage
 REDIS_URL=redis://localhost:6379

--- a/vault_engine/.env.example
+++ b/vault_engine/.env.example
@@ -15,11 +15,8 @@ LOCAL_ENGINE_KEY=your_local_engine_key
 VAULT_REDIS_URL=redis://localhost:6380
 
 # AES-256-CBC encryption settings
-VAULT_ENCRYPTION_KEY=32_byte_base64_key_here
-VAULT_ENCRYPTION_IV=16_byte_base64_iv_here
-
-# OAuth client settings for Gmail (example)
-GMAIL_CLIENT_ID=your_gmail_client_id
-GMAIL_CLIENT_SECRET=your_gmail_client_secret
-GMAIL_REDIRECT_URI=http://localhost:8000/auth/callback/gmail
-GMAIL_SCOPE=https://www.googleapis.com/auth/gmail.send
+# Keys must be base64 encoded
+# ``VAULT_ENCRYPTION_KEY`` -> 32 bytes when decoded
+# ``VAULT_ENCRYPTION_IV``  -> 16 bytes when decoded
+VAULT_ENCRYPTION_KEY=base64_32_byte_key
+VAULT_ENCRYPTION_IV=base64_16_byte_iv


### PR DESCRIPTION
## Summary
- update `.env.example` for `action_engine`, `engine_control`, and `vault_engine`
- add API key examples for `goal_engine` and `strategy_engine`
- document calendar OAuth values for `sync_engine`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829c0fd388832eadc2b77f970c77b4