### PR TITLE
Add detailed Engine Control README

### DIFF
--- a/engine_control/README.md
+++ b/engine_control/README.md
@@ -1,87 +1,67 @@
 # Engine Control
 
-Engine Control is the central coordination service for all engines in PURAIFI. It manages engine registration, platform availability and system policies rather than performing actions itself.
+## 1. Introduction: What is Engine Control?
+Engine Control is the meta-engine that governs every other engine in the PURAIFI ecosystem. It does not execute tasks itself. Instead it registers engines, enforces permissions, manages platform availability and serves global configuration. By centralizing these checks it ensures that only authorised engines can interact with external services. End users never call this API directly—only engines communicate with it.
 
-## Overview & Role
+## 2. Permission Model
+Engine Control follows a strict zero-trust approach:
+- Each engine registers with an `engine_id` and receives a signed `engine_token`.
+- Every action request is validated against the stored permissions; there are no default allowances.
+- Platform status (for example `maintenance`) can override individual engine permissions.
+- Engines may depend on other engines. If a dependency is inactive, related actions are denied.
 
-Engine Control acts as the meta-engine that governs what other engines may do. Engines authenticate to this service in order to register themselves, retrieve configuration, and check permissions before carrying out tasks on external platforms. The service is stateless and designed to run as a cloud API reachable by all engines but not by end users.
-
-Main responsibilities include:
-
-- Registering and validating engines
-- Controlling the list of supported platforms and their statuses
-- Checking whether an action is allowed for a particular engine
-- Storing global feature flags and API versions
-- Logging engine activity for auditing purposes
-
-## System Context
-
-Engine Control runs as a standalone HTTP service. Other engines such as the Action Engine or Vault Engine query it via REST or gRPC to verify whether they are allowed to perform a given operation. No engine is implicitly trusted; each request requires the caller to present its engine ID and secret key.
-
-## Core API Endpoints
-
-The service exposes several endpoints to handle registration, permission checks and configuration. Example routes are shown below.
-
-| Endpoint | Method | Description |
+## 3. Core API Endpoints
+| Endpoint | Method | Purpose |
 | --- | --- | --- |
-| `/engines/register` | `POST` | Register a new engine and define its permissions and dependencies. Returns a token used for future calls. |
-| `/engines/validate` | `POST` | Validate an engine's identity using its token. Used by engines to confirm they are recognised. |
-| `/actions/check` | `POST` | Determine whether a given engine can perform an action on a platform. Also returns any required scopes. |
-| `/platforms/list` | `GET` | List available platforms with their current status (`active`, `maintenance`, `deprecated`). |
-| `/config/global` | `GET` | Fetch global feature flags and API version information. |
-| `/log/engine_event` | `POST` | Submit event logs such as errors or metrics for aggregation. |
+| `/engines/register` | `POST` | Register a new engine and obtain a token |
+| `/engines/validate` | `POST` | Confirm engine identity |
+| `/actions/check` | `POST` | Ask if a proposed action is allowed |
+| `/platforms/list` | `GET` | Get platform statuses and available scopes |
+| `/config/global` | `GET` | Retrieve system-wide flags, versions and modes |
+| `/log/engine_event` | `POST` | Submit telemetry or logs from engines |
 
-### Example flow: registering an engine
+**Request example:**
+```json
+POST /engines/register
+{
+  "engine_id": "sync",
+  "permissions": {"gmail": {"read": ["gmail.read"]}}
+}
+```
+**Response example:**
+```json
+{
+  "engine_token": "<signed-token>"
+}
+```
 
-1. A new engine sends a `POST /engines/register` request with its desired permissions.
-2. Engine Control stores the engine entry and returns a unique authentication token.
-3. The engine uses this token for subsequent calls via the `X-Engine-ID` and `X-Engine-Key` headers.
+## 4. Typical Flows
+### Registering a new engine
+Send a `POST /engines/register` request with the desired permissions and dependencies. The response contains an `engine_token` used in future requests.
 
-### Example flow: requesting permission for an action
+### Performing an action
+Before calling another engine such as Vault, the caller must check its rights via `POST /actions/check`.
+If the platform is in maintenance or the scope is missing, the response will deny the action with a reason.
 
-1. Before performing an action, the engine calls `POST /actions/check` with its engine ID, the target platform and the action type.
-2. Engine Control verifies the engine's registration, platform status and permission set.
-3. A response is returned indicating whether the action is allowed and which scopes are required.
+### Getting global config
+Engines periodically call `GET /config/global` to retrieve feature flags or version information that might alter their behaviour.
 
-### Handling platform maintenance
+## 5. Internal Model (What Engine Control stores)
+For every engine the service records:
+- `engine_id`, `name` and a `token`
+- Allowed platforms and actions
+- Optional `depends_on` list
 
-When a platform is put into maintenance mode via configuration, `POST /platforms/list` will show its status as `maintenance`. Permission checks for that platform will fail until the status is restored to `active`.
+Platform status is tracked globally and consulted during every permission check.
 
-## Permission & Policy Model
+## 6. Logging, Monitoring & Deactivation
+Every request receives a unique `request_id` and is logged with fields such as `engine_id`, `action`, `platform`, result and timestamp. Engines can be flagged as inactive; once flagged, all calls from them are rejected. Alerts can trigger if repeated failures or suspicious behaviour is detected.
 
-Each engine is registered with a set of allowed platforms and actions. The service enforces these policies on every permission check. Dynamic feature flags can temporarily enable or disable platforms or specific use cases without requiring code changes.
+## 7. Scalability & Extensibility
+The API is stateless which allows horizontal scaling. New engines or platforms can be added without code changes because permissions and platform status are stored dynamically. Feature flags and version-aware responses enable gradual rollout and warnings when an engine is outdated.
 
-## Security Model
-
-Engine Control follows a zero-trust approach:
-
-- Requests must include a valid engine ID and token.
-- Permissions are checked for every action; lack of permission results in denial.
-- All operations are logged with request IDs to provide a full audit trail.
-
-There is no implicit trust between engines. Even internal calls are authenticated and logged.
-
-## Scalability & Extensibility
-
-The API is stateless and suitable for horizontal scaling behind a load balancer. Engines can be onboarded dynamically by calling the registration endpoint, and platform statuses can be updated without redeploying. Responses are version-aware so that outdated clients can be warned when new features become available.
-
-## Internal Logic
-
-While the public API focuses on configuration and authorization, internally the service maintains in‑memory stores for engines and platform status. Each request goes through an authentication middleware that validates the `X-Engine-ID` and `X-Engine-Key` headers. Permission checks combine the engine's stored permissions with the platform status to decide whether an action is allowed. All endpoints use a JSON logger that attaches a per‑request UUID for traceability.
-
-## Sample Development Setup
-
-1. Install requirements:
-
-   ```bash
-   pip install fastapi uvicorn
-   ```
-
-2. Start the service:
-
-   ```bash
-   uvicorn engine_control.main:app --reload
-   ```
-
-Other engines can then send HTTP requests to this local instance. Tests can be run with `pytest` from the repository root.
-
+## 8. Development Setup
+```bash
+pip install fastapi uvicorn
+uvicorn engine_control.main:app --reload
+```


### PR DESCRIPTION
## Summary
- rewrite `engine_control/README.md` with clear introduction, permission model and API details
- include example JSON requests/responses and typical usage flows
- document logging, scalability and setup steps

## Testing
- `pytest -q` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_6882a8097c7c832e84c99728e04873c9