### PR TITLE
Implement action engine modules

### DIFF
--- a/action_engine/actions_registry.py
+++ b/action_engine/actions_registry.py
@@ -1,10 +1,40 @@
-"""Registry of supported actions for each platform."""
+"""Registry mapping platforms and actions to adapter callables."""
 
-from typing import Dict, List
+from __future__ import annotations
 
-ACTIONS_REGISTRY: Dict[str, List[str]] = {
-    "gmail": ["perform_action"],
-    "google_calendar": ["create_event"],
-    "notion": ["create_task"],
-    "zapier": ["perform_action"],
+from typing import Callable, Dict, Iterable
+
+from .adapters import (
+    gmail_adapter,
+    google_calendar_adapter,
+    notion_adapter,
+    zapier_adapter,
+)
+
+
+#: Nested mapping of ``platform -> action_type -> callable`` used by the router
+ACTION_FUNCTIONS: Dict[str, Dict[str, Callable[..., object]]] = {
+    "gmail": {
+        "perform_action": gmail_adapter.perform_action,
+        "send_email": gmail_adapter.send_email,
+    },
+    "google_calendar": {"create_event": google_calendar_adapter.create_event},
+    "notion": {"create_task": notion_adapter.create_task},
+    "zapier": {
+        "perform_action": zapier_adapter.perform_action,
+        "trigger_zap": zapier_adapter.trigger_zap,
+    },
 }
+
+
+def get_action_function(platform: str, action_type: str) -> Callable[..., object] | None:
+    """Return the adapter callable for ``platform``/``action_type`` if registered."""
+
+    return ACTION_FUNCTIONS.get(platform, {}).get(action_type)
+
+
+def supported_actions(platform: str) -> Iterable[str]:
+    """Return an iterable of supported action types for ``platform``."""
+
+    return ACTION_FUNCTIONS.get(platform, {}).keys()
+

--- a/action_engine/formatter.py
+++ b/action_engine/formatter.py
@@ -1,0 +1,18 @@
+"""Helpers for formatting action payloads."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def format_payload(platform: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return ``payload`` possibly transformed for ``platform``.
+
+    Currently this function simply returns the payload unchanged but acts as a
+    central place to apply any platform specific formatting rules in the
+    future.
+    """
+
+    # Placeholder for platform specific formatting logic.
+    return dict(payload)
+

--- a/action_engine/logging/logger.py
+++ b/action_engine/logging/logger.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from typing import Any
-from datetime import datetime
+from datetime import datetime, timezone
 import contextvars
 import uuid
 
@@ -25,7 +25,7 @@ class JsonFormatter(logging.Formatter):
             "level": record.levelname,
             "name": record.name,
             "message": record.getMessage(),
-            "time": datetime.utcnow().isoformat(),
+            "time": datetime.now(timezone.utc).isoformat(),
         }
         if record.exc_info:
             log_record["exception"] = self.formatException(record.exc_info)

--- a/action_engine/utils/common.py
+++ b/action_engine/utils/common.py
@@ -1,0 +1,14 @@
+"""Miscellaneous helper utilities used across the engine."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def merge_dicts(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a new dictionary containing ``a`` updated with ``b``."""
+
+    result = dict(a)
+    result.update(b)
+    return result
+


### PR DESCRIPTION
## Summary
- finish action engine plumbing
- add action mapping registry and use it from router
- provide minimal formatter and utilities
- improve log time handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882b32d6074832eb150f27bcffd0d20